### PR TITLE
refactor(cli): renderizar tablas con rich en vez de padding manual

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pyarrow>=24.0.0",
     "requests>=2.34.2",
     "platformdirs>=4.10.0",
+    "rich>=14.0",
 ]
 
 

--- a/src/chile_hub/_render.py
+++ b/src/chile_hub/_render.py
@@ -1,0 +1,43 @@
+"""Renderizado de tablas de la CLI con rich.
+
+Devuelve texto plano (box-drawing Unicode, sin ANSI) para que la salida sea
+estable en tests y en pipes. El color es un follow-up deferido.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Sequence
+
+from rich.console import Console
+from rich.table import Table
+
+
+def render_table(
+    title: str,
+    headers: Sequence[str],
+    rows: Sequence[Sequence[str]],
+    *,
+    width: int = 120,
+) -> str:
+    """Renderiza una tabla a texto plano, precedida por *title*.
+
+    El título se emite tal cual en la primera linea (los tests lo verifican por
+    subcadena). La tabla se renderiza sin color para mantener la salida estable.
+    """
+    table = Table(show_edge=True, expand=False)
+    for header in headers:
+        table.add_column(header, overflow="fold")
+    for row in rows:
+        table.add_row(*[str(cell) for cell in row])
+
+    buffer = io.StringIO()
+    console = Console(
+        file=buffer,
+        width=width,
+        force_terminal=False,  # sin ANSI
+        no_color=True,
+        highlight=False,
+    )
+    console.print(table)
+    return f"{title}\n\n{buffer.getvalue()}"

--- a/src/chile_hub/core.py
+++ b/src/chile_hub/core.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 import polars as pl
 import requests
 
+from ._render import render_table
 from .data_manager import ChileHubDataManager
 from .exceptions import (
     ChileHubDataError,
@@ -235,32 +236,22 @@ class ChileHub:
 
     def top_issue_table(self) -> str:
         top_issue = self.top_issue()
-        lines = ["chile-hub top issue", ""]
         if not top_issue:
-            lines.append("Sin top issue activo.")
-            return "\n".join(lines) + "\n"
+            return "chile-hub top issue\n\nSin top issue activo.\n"
 
         rows = [
-            ("dataset", top_issue.get("dataset", "unknown")),
-            ("attention_priority", str(top_issue.get("attention_priority", "unknown"))),
-            (
-                "build_freshness_status",
-                top_issue.get("build_freshness_status", "unknown"),
-            ),
-            (
-                "current_freshness_status",
-                top_issue.get("current_freshness_status", "unknown"),
-            ),
-            ("drift_status", top_issue.get("drift_status", "unknown")),
-            ("degradation_status", top_issue.get("degradation_status", "unknown")),
-            ("warning_count", str(top_issue.get("warning_count", 0))),
-            ("source_detail", top_issue.get("source_detail", "unknown")),
-            ("diagnostic_summary", top_issue.get("diagnostic_summary", "unknown")),
-            ("recommended_action", top_issue.get("recommended_action", "unknown")),
+            ["dataset", top_issue.get("dataset", "unknown")],
+            ["attention_priority", str(top_issue.get("attention_priority", "unknown"))],
+            ["build_freshness_status", top_issue.get("build_freshness_status", "unknown")],
+            ["current_freshness_status", top_issue.get("current_freshness_status", "unknown")],
+            ["drift_status", top_issue.get("drift_status", "unknown")],
+            ["degradation_status", top_issue.get("degradation_status", "unknown")],
+            ["warning_count", str(top_issue.get("warning_count", 0))],
+            ["source_detail", top_issue.get("source_detail", "unknown")],
+            ["diagnostic_summary", top_issue.get("diagnostic_summary", "unknown")],
+            ["recommended_action", top_issue.get("recommended_action", "unknown")],
         ]
-        label_width = max(len(label) for label, _ in rows)
-        lines.extend(f"{label.ljust(label_width)} : {value}" for label, value in rows)
-        return "\n".join(lines) + "\n"
+        return render_table("chile-hub top issue", ["key", "value"], rows)
 
     def list_datasets(self) -> list[str]:
         return [entry["dataset"] for entry in self.catalog.get("datasets", [])]
@@ -523,27 +514,35 @@ class ChileHub:
             for entry in self.catalog.get("datasets", [])
         ]
 
-    def summary_table(self):
+    def summary_table(self) -> str:
         rows = self.summary()
-        lines = ["chile-hub summary", ""]
-        lines.append(
-            "dataset      mode      records  freshness  coverage        validation  drift     warnings"
+        table_rows = [
+            [
+                entry.get("dataset", "unknown"),
+                entry.get("source_mode", "unknown"),
+                str(entry.get("record_count", "N/D")),
+                entry.get("freshness_status", "unknown"),
+                entry.get("coverage_status", "unknown"),
+                entry.get("validation_status", "unknown"),
+                entry.get("drift_status", "unknown"),
+                str(entry.get("warning_count", 0)),
+            ]
+            for entry in rows
+        ]
+        return render_table(
+            "chile-hub summary",
+            [
+                "dataset",
+                "mode",
+                "records",
+                "freshness",
+                "coverage",
+                "validation",
+                "drift",
+                "warnings",
+            ],
+            table_rows,
         )
-        lines.append(
-            "-----------  --------  -------  ---------  --------------  ----------  --------  --------"
-        )
-        for entry in rows:
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{str(entry.get('record_count', 'N/D')):<7}  "
-                f"{entry.get('freshness_status', 'unknown'):<9}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('validation_status', 'unknown'):<10}  "
-                f"{entry.get('drift_status', 'unknown'):<8}  "
-                f"{str(entry.get('warning_count', 0)):<8}"
-            )
-        return "\n".join(lines) + "\n"
 
     def snapshot_text(self):
         overview = self.overview()
@@ -676,26 +675,30 @@ class ChileHub:
         label_width = max(len(label) for label, _ in rows)
         lines = ["chile-hub snapshot table", ""]
         lines.extend(f"{label.ljust(label_width)} : {value}" for label, value in rows)
-        lines.append("")
-        lines.append(
-            "dataset      mode      validation  build      current    coverage        drift"
-        )
-        lines.append(
-            "-----------  --------  ----------  ---------  ---------  --------------  --------"
-        )
 
+        dataset_rows = []
         for entry in overview.get("datasets", []):
             runtime_freshness = freshness_by_dataset.get(entry.get("dataset"), {})
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('validation_status', 'unknown'):<10}  "
-                f"{entry.get('freshness_status', 'unknown'):<9}  "
-                f"{runtime_freshness.get('current_freshness_status', 'unknown'):<9}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('drift_status', 'unknown'):<8}"
+            dataset_rows.append(
+                [
+                    entry.get("dataset", "unknown"),
+                    entry.get("source_mode", "unknown"),
+                    entry.get("validation_status", "unknown"),
+                    entry.get("freshness_status", "unknown"),
+                    runtime_freshness.get("current_freshness_status", "unknown"),
+                    entry.get("coverage_status", "unknown"),
+                    entry.get("drift_status", "unknown"),
+                ]
             )
 
+        lines.append("")
+        lines.append(
+            render_table(
+                "",
+                ["dataset", "mode", "validation", "build", "current", "coverage", "drift"],
+                dataset_rows,
+            )
+        )
         return "\n".join(lines) + "\n"
 
     def artifacts(self, dataset_name=None):
@@ -717,11 +720,7 @@ class ChileHub:
 
     def shared_artifacts_table(self, shared_type=None, format=None):
         artifacts = self.shared_artifacts(shared_type, format)
-        lines = ["chile-hub shared artifacts", ""]
-        lines.append("shared_type             format    size      path")
-        lines.append(
-            "----------------------  --------  --------  -----------------------------------------------"
-        )
+        table_rows = []
         for entry in artifacts:
             size_bytes = entry.get("size_bytes")
             if isinstance(size_bytes, int):
@@ -731,13 +730,19 @@ class ChileHub:
                     size_label = f"{size_bytes / 1024:.1f} KB"
             else:
                 size_label = "N/D"
-            lines.append(
-                f"{entry.get('shared_type', 'unknown'):<22}  "
-                f"{entry.get('format', 'unknown'):<8}  "
-                f"{size_label:<8}  "
-                f"{entry.get('path', 'unknown')}"
+            table_rows.append(
+                [
+                    entry.get("shared_type", "unknown"),
+                    entry.get("format", "unknown"),
+                    size_label,
+                    entry.get("path", "unknown"),
+                ]
             )
-        return "\n".join(lines) + "\n"
+        return render_table(
+            "chile-hub shared artifacts",
+            ["shared_type", "format", "size", "path"],
+            table_rows,
+        )
 
     def reports(self):
         return self.bundle().get("reports", {})
@@ -759,11 +764,7 @@ class ChileHub:
 
     def report_index_table(self):
         rows = self.report_index()
-        lines = ["chile-hub report index", ""]
-        lines.append("report_key              shared_type            format    size      path")
-        lines.append(
-            "----------------------  ---------------------  --------  --------  -----------------------------------------------"
-        )
+        table_rows = []
         for entry in rows:
             size_bytes = entry.get("size_bytes")
             if isinstance(size_bytes, int):
@@ -773,14 +774,20 @@ class ChileHub:
                     size_label = f"{size_bytes / 1024:.1f} KB"
             else:
                 size_label = "N/D"
-            lines.append(
-                f"{entry.get('report_key', 'unknown'):<22}  "
-                f"{entry.get('shared_type', 'unknown'):<21}  "
-                f"{entry.get('format', 'unknown'):<8}  "
-                f"{size_label:<8}  "
-                f"{entry.get('path', 'unknown')}"
+            table_rows.append(
+                [
+                    entry.get("report_key", "unknown"),
+                    entry.get("shared_type", "unknown"),
+                    entry.get("format", "unknown"),
+                    size_label,
+                    entry.get("path", "unknown"),
+                ]
             )
-        return "\n".join(lines) + "\n"
+        return render_table(
+            "chile-hub report index",
+            ["report_key", "shared_type", "format", "size", "path"],
+            table_rows,
+        )
 
     def get_report(self, shared_type, format):
         for entry in self.reports().values():
@@ -913,18 +920,27 @@ class ChileHub:
         label_width = max(len(label) for label, _ in rows)
         lines = ["chile-hub overview", ""]
         lines.extend(f"{label.ljust(label_width)} : {value}" for label, value in rows)
+
+        dataset_rows = [
+            [
+                entry.get("dataset", "unknown"),
+                entry.get("source_mode", "unknown"),
+                entry.get("validation_status", "unknown"),
+                entry.get("freshness_status", "unknown"),
+                entry.get("coverage_status", "unknown"),
+                entry.get("drift_status", "unknown"),
+            ]
+            for entry in overview.get("datasets", [])
+        ]
+
         lines.append("")
-        lines.append("dataset      mode      validation  build      coverage        drift")
-        lines.append("-----------  --------  ----------  ---------  --------------  --------")
-        for entry in overview.get("datasets", []):
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('validation_status', 'unknown'):<10}  "
-                f"{entry.get('freshness_status', 'unknown'):<9}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('drift_status', 'unknown'):<8}"
+        lines.append(
+            render_table(
+                "",
+                ["dataset", "mode", "validation", "build", "coverage", "drift"],
+                dataset_rows,
             )
+        )
         return "\n".join(lines) + "\n"
 
     def inventory(self):
@@ -989,13 +1005,7 @@ class ChileHub:
 
     def inventory_table(self):
         rows = self.inventory()
-        lines = ["chile-hub inventory", ""]
-        lines.append(
-            "dataset      mode      records  outputs        size      freshness  coverage        drift"
-        )
-        lines.append(
-            "-----------  --------  -------  -------------  --------  ---------  --------------  --------"
-        )
+        table_rows = []
         for entry in rows:
             outputs = ",".join(entry.get("published_outputs", [])) or "N/D"
             size_bytes = entry.get("total_size_bytes")
@@ -1006,17 +1016,23 @@ class ChileHub:
                     size_label = f"{size_bytes / 1024:.1f} KB"
             else:
                 size_label = "N/D"
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{str(entry.get('record_count', 'N/D')):<7}  "
-                f"{outputs:<13}  "
-                f"{size_label:<8}  "
-                f"{entry.get('freshness_status', 'unknown'):<9}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('drift_status', 'unknown'):<8}"
+            table_rows.append(
+                [
+                    entry.get("dataset", "unknown"),
+                    entry.get("source_mode", "unknown"),
+                    str(entry.get("record_count", "N/D")),
+                    outputs,
+                    size_label,
+                    entry.get("freshness_status", "unknown"),
+                    entry.get("coverage_status", "unknown"),
+                    entry.get("drift_status", "unknown"),
+                ]
             )
-        return "\n".join(lines) + "\n"
+        return render_table(
+            "chile-hub inventory",
+            ["dataset", "mode", "records", "outputs", "size", "freshness", "coverage", "drift"],
+            table_rows,
+        )
 
     def health(self):
         health = self._load_hub_health()
@@ -1094,11 +1110,7 @@ class ChileHub:
 
     def check_sources_table(self, results: list[dict[str, Any]]) -> str:
         """Formatea el resultado de check_sources como una tabla amigable para terminal."""
-        lines = ["chile-hub check-sources", ""]
-        lines.append("dataset      status   code  latency    source name         url")
-        lines.append(
-            "-----------  -------  ----  ---------  ------------------  ------------------------------------------------"
-        )
+        table_rows = []
         for entry in results:
             status = entry.get("status", "unknown")
             code = str(entry.get("status_code")) if entry.get("status_code") is not None else "N/A"
@@ -1108,16 +1120,21 @@ class ChileHub:
             url = entry.get("url", "N/A")
             if len(url) > 48:
                 url = url[:45] + "..."
-
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{status:<7}  "
-                f"{code:<4}  "
-                f"{latency:<9}  "
-                f"{entry.get('source_name', 'unknown'):<18}  "
-                f"{url}"
+            table_rows.append(
+                [
+                    entry.get("dataset", "unknown"),
+                    status,
+                    code,
+                    latency,
+                    entry.get("source_name", "unknown"),
+                    url,
+                ]
             )
-        return "\n".join(lines) + "\n"
+        return render_table(
+            "chile-hub check-sources",
+            ["dataset", "status", "code", "latency", "source name", "url"],
+            table_rows,
+        )
 
     def dataset_quality(self):
         """Devuelve la tarjeta de puntuación de calidad multidimensional por dataset."""
@@ -1125,40 +1142,31 @@ class ChileHub:
 
     def status_table(self):
         status = self.status()
-        rows = [
-            ("generated_at_utc", status.get("generated_at_utc", "unknown")),
-            ("overall_status", status.get("overall_status", "unknown")),
-            ("dataset_count", str(status.get("dataset_count", 0))),
-            ("live_count", str(status.get("live_count", 0))),
-            ("fallback_count", str(status.get("fallback_count", 0))),
-            ("stale_count", str(status.get("stale_count", 0))),
-            ("drifted_count", str(status.get("drifted_count", 0))),
-            ("degraded_count", str(status.get("degraded_count", 0))),
-            ("warning_count", str(status.get("warning_count", 0))),
+        table_rows = [
+            ["generated_at_utc", status.get("generated_at_utc", "unknown")],
+            ["overall_status", status.get("overall_status", "unknown")],
+            ["dataset_count", str(status.get("dataset_count", 0))],
+            ["live_count", str(status.get("live_count", 0))],
+            ["fallback_count", str(status.get("fallback_count", 0))],
+            ["stale_count", str(status.get("stale_count", 0))],
+            ["drifted_count", str(status.get("drifted_count", 0))],
+            ["degraded_count", str(status.get("degraded_count", 0))],
+            ["warning_count", str(status.get("warning_count", 0))],
         ]
         top_issue = status.get("top_issue")
         if top_issue:
-            rows.extend(
+            table_rows.extend(
                 [
-                    ("top_issue", top_issue.get("dataset", "unknown")),
-                    (
-                        "top_issue_reason",
-                        top_issue.get("diagnostic_summary", "unknown"),
-                    ),
-                    (
-                        "top_issue_action",
-                        top_issue.get("recommended_action", "unknown"),
-                    ),
-                    (
+                    ["top_issue", top_issue.get("dataset", "unknown")],
+                    ["top_issue_reason", top_issue.get("diagnostic_summary", "unknown")],
+                    ["top_issue_action", top_issue.get("recommended_action", "unknown")],
+                    [
                         "top_issue_summary",
                         status.get("top_issue_summary", format_top_issue_summary(top_issue)),
-                    ),
+                    ],
                 ]
             )
-        label_width = max(len(label) for label, _ in rows)
-        lines = ["chile-hub status", ""]
-        lines.extend(f"{label.ljust(label_width)} : {value}" for label, value in rows)
-        return "\n".join(lines) + "\n"
+        return render_table("chile-hub status", ["key", "value"], table_rows)
 
     def health_table(self):
         health = self.health()
@@ -1175,25 +1183,39 @@ class ChileHub:
             f"stale={health.get('stale_count', 0)} | "
             f"drifted={health.get('drifted_count', 0)}"
         )
+
+        dataset_rows = [
+            [
+                entry.get("dataset", "unknown"),
+                entry.get("severity", "unknown"),
+                entry.get("source_mode", "unknown"),
+                entry.get("freshness_status", "unknown"),
+                entry.get("validation_status", "unknown"),
+                entry.get("publishability_status", "unknown"),
+                entry.get("coverage_status", "unknown"),
+                entry.get("drift_status", "unknown"),
+                str(entry.get("warning_count", 0)),
+            ]
+            for entry in health.get("datasets", [])
+        ]
         lines.append("")
         lines.append(
-            "dataset      severity  mode      freshness  validation  reuse    coverage        drift     warnings"
-        )
-        lines.append(
-            "-----------  --------  --------  ---------  ----------  -------  --------------  --------  --------"
-        )
-        for entry in health.get("datasets", []):
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('severity', 'unknown'):<8}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('freshness_status', 'unknown'):<9}  "
-                f"{entry.get('validation_status', 'unknown'):<10}  "
-                f"{entry.get('publishability_status', 'unknown'):<7}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('drift_status', 'unknown'):<8}  "
-                f"{str(entry.get('warning_count', 0)):<8}"
+            render_table(
+                "",
+                [
+                    "dataset",
+                    "severity",
+                    "mode",
+                    "freshness",
+                    "validation",
+                    "reuse",
+                    "coverage",
+                    "drift",
+                    "warnings",
+                ],
+                dataset_rows,
             )
+        )
         return "\n".join(lines) + "\n"
 
     def freshness_audit(self):
@@ -1328,30 +1350,46 @@ class ChileHub:
             lines.append(
                 f"top_issue_summary={runtime.get('top_issue_summary', format_top_issue_summary(top_issue))}"
             )
-        lines.append("")
-        lines.append(
-            "dataset      mode      severity  build      current    age_h   max_h   coverage        drift     warnings"
-        )
-        lines.append(
-            "-----------  --------  --------  ---------  ---------  ------  ------  --------------  --------  --------"
-        )
+
+        dataset_rows = []
         for entry in runtime.get("datasets", []):
             age = entry.get("current_age_hours")
             age_label = f"{age:.2f}" if isinstance(age, (int, float)) else "N/D"
             max_age = entry.get("max_age_hours")
             max_age_label = str(max_age) if isinstance(max_age, (int, float)) else "N/D"
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('severity', 'unknown'):<8}  "
-                f"{entry.get('build_freshness_status', 'unknown'):<9}  "
-                f"{entry.get('current_freshness_status', 'unknown'):<9}  "
-                f"{age_label:<6}  "
-                f"{max_age_label:<6}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('drift_status', 'unknown'):<8}  "
-                f"{str(entry.get('warning_count', 0)):<8}"
+            dataset_rows.append(
+                [
+                    entry.get("dataset", "unknown"),
+                    entry.get("source_mode", "unknown"),
+                    entry.get("severity", "unknown"),
+                    entry.get("build_freshness_status", "unknown"),
+                    entry.get("current_freshness_status", "unknown"),
+                    age_label,
+                    max_age_label,
+                    entry.get("coverage_status", "unknown"),
+                    entry.get("drift_status", "unknown"),
+                    str(entry.get("warning_count", 0)),
+                ]
             )
+        lines.append("")
+        lines.append(
+            render_table(
+                "",
+                [
+                    "dataset",
+                    "mode",
+                    "severity",
+                    "build",
+                    "current",
+                    "age_h",
+                    "max_h",
+                    "coverage",
+                    "drift",
+                    "warnings",
+                ],
+                dataset_rows,
+            )
+        )
         return "\n".join(lines) + "\n"
 
     def freshness_audit_table(self):
@@ -1364,23 +1402,32 @@ class ChileHub:
             f"stale={audit.get('stale_count', 0)} | "
             f"unknown={audit.get('unknown_count', 0)}"
         )
-        lines.append("")
-        lines.append("dataset      mode      build      current    age_h   max_h   label")
-        lines.append("-----------  --------  ---------  ---------  ------  ------  --------")
+
+        dataset_rows = []
         for entry in audit.get("datasets", []):
             age = entry.get("current_age_hours")
             age_label = f"{age:.2f}" if isinstance(age, (int, float)) else "N/D"
             max_age = entry.get("max_age_hours")
             max_age_label = str(max_age) if isinstance(max_age, (int, float)) else "N/D"
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('build_freshness_status', 'unknown'):<9}  "
-                f"{entry.get('current_freshness_status', 'unknown'):<9}  "
-                f"{age_label:<6}  "
-                f"{max_age_label:<6}  "
-                f"{entry.get('freshness_label', 'N/D')}"
+            dataset_rows.append(
+                [
+                    entry.get("dataset", "unknown"),
+                    entry.get("source_mode", "unknown"),
+                    entry.get("build_freshness_status", "unknown"),
+                    entry.get("current_freshness_status", "unknown"),
+                    age_label,
+                    max_age_label,
+                    entry.get("freshness_label", "N/D"),
+                ]
             )
+        lines.append("")
+        lines.append(
+            render_table(
+                "",
+                ["dataset", "mode", "build", "current", "age_h", "max_h", "label"],
+                dataset_rows,
+            )
+        )
         return "\n".join(lines) + "\n"
 
     def bundle(self):
@@ -1395,11 +1442,7 @@ class ChileHub:
 
     def packages_table(self):
         packages = self.packages()
-        lines = ["chile-hub packages", ""]
-        lines.append("package_type  size      checksum  path")
-        lines.append(
-            "------------  --------  --------  -----------------------------------------------"
-        )
+        table_rows = []
         for package in packages:
             size_bytes = package.get("size_bytes")
             if isinstance(size_bytes, int):
@@ -1409,13 +1452,19 @@ class ChileHub:
                     size_label = f"{size_bytes / 1024:.1f} KB"
             else:
                 size_label = "N/D"
-            lines.append(
-                f"{package.get('package_type', 'unknown'):<12}  "
-                f"{size_label:<8}  "
-                f"{package.get('checksum_algorithm', 'unknown'):<8}  "
-                f"{package.get('path', 'unknown')}"
+            table_rows.append(
+                [
+                    package.get("package_type", "unknown"),
+                    size_label,
+                    package.get("checksum_algorithm", "unknown"),
+                    package.get("path", "unknown"),
+                ]
             )
-        return "\n".join(lines) + "\n"
+        return render_table(
+            "chile-hub packages",
+            ["package_type", "size", "checksum", "path"],
+            table_rows,
+        )
 
     def primary_package(self, package_type="zip"):
         for package in self.packages():
@@ -1447,20 +1496,27 @@ class ChileHub:
             f"unknown={report.get('unknown_count', 0)} | "
             f"datasets={report.get('dataset_count', 0)}"
         )
-        lines.append("")
-        lines.append("dataset      status         reuse_status       attribution  license")
-        lines.append(
-            "-----------  -------------  -----------------  -----------  ----------------------------------------"
-        )
+
+        dataset_rows = []
         for entry in report.get("datasets", []):
             attribution = "yes" if entry.get("attribution_required") else "no"
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('publishability_status', 'unknown'):<13}  "
-                f"{entry.get('reuse_status', 'unknown'):<17}  "
-                f"{attribution:<11}  "
-                f"{entry.get('license', 'unknown')}"
+            dataset_rows.append(
+                [
+                    entry.get("dataset", "unknown"),
+                    entry.get("publishability_status", "unknown"),
+                    entry.get("reuse_status", "unknown"),
+                    attribution,
+                    entry.get("license", "unknown"),
+                ]
             )
+        lines.append("")
+        lines.append(
+            render_table(
+                "",
+                ["dataset", "status", "reuse_status", "attribution", "license"],
+                dataset_rows,
+            )
+        )
         return "\n".join(lines) + "\n"
 
     def provenance(self):
@@ -1474,22 +1530,26 @@ class ChileHub:
             f"live={report.get('live_count', 0)} | "
             f"fallback={report.get('fallback_count', 0)}"
         )
+
+        dataset_rows = [
+            [
+                entry.get("dataset", "unknown"),
+                entry.get("source_mode", "unknown"),
+                entry.get("source_detail", "unknown"),
+                entry.get("freshness_status", "unknown"),
+                str(entry.get("warning_count", 0)),
+                entry.get("refreshed_at_utc", "unknown"),
+            ]
+            for entry in report.get("datasets", [])
+        ]
         lines.append("")
         lines.append(
-            "dataset      mode      source                        freshness  warnings  refreshed_at_utc"
-        )
-        lines.append(
-            "-----------  --------  ----------------------------  ---------  --------  --------------------------------"
-        )
-        for entry in report.get("datasets", []):
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('source_detail', 'unknown'):<28}  "
-                f"{entry.get('freshness_status', 'unknown'):<9}  "
-                f"{entry.get('warning_count', 0):<8}  "
-                f"{entry.get('refreshed_at_utc', 'unknown')}"
+            render_table(
+                "",
+                ["dataset", "mode", "source", "freshness", "warnings", "refreshed_at_utc"],
+                dataset_rows,
             )
+        )
         return "\n".join(lines) + "\n"
 
     def drift(self):
@@ -1506,18 +1566,26 @@ class ChileHub:
             f"partial_coverage={report.get('partial_coverage_count', 0)} | "
             f"degraded={report.get('degraded_count', 0)}"
         )
+
+        dataset_rows = [
+            [
+                entry.get("dataset", "unknown"),
+                entry.get("drift_status", "unknown"),
+                entry.get("source_mode", "unknown"),
+                entry.get("coverage_status", "unknown"),
+                entry.get("degradation_status", "unknown"),
+                str(entry.get("warning_count", 0)),
+            ]
+            for entry in report.get("datasets", [])
+        ]
         lines.append("")
-        lines.append("dataset      drift      mode      coverage        degradation  warnings")
-        lines.append("-----------  ---------  --------  --------------  -----------  --------")
-        for entry in report.get("datasets", []):
-            lines.append(
-                f"{entry.get('dataset', 'unknown'):<11}  "
-                f"{entry.get('drift_status', 'unknown'):<9}  "
-                f"{entry.get('source_mode', 'unknown'):<8}  "
-                f"{entry.get('coverage_status', 'unknown'):<14}  "
-                f"{entry.get('degradation_status', 'unknown'):<11}  "
-                f"{entry.get('warning_count', 0)}"
+        lines.append(
+            render_table(
+                "",
+                ["dataset", "drift", "mode", "coverage", "degradation", "warnings"],
+                dataset_rows,
             )
+        )
         return "\n".join(lines) + "\n"
 
 

--- a/tests/test_chile_hub.py
+++ b/tests/test_chile_hub.py
@@ -281,7 +281,9 @@ class ChileHubTests(unittest.TestCase):
     def test_summary_table(self):
         table = self.hub.summary_table()
         self.assertIn("chile-hub summary", table)
-        self.assertIn("dataset      mode      records", table)
+        self.assertIn("dataset", table)
+        self.assertIn("mode", table)
+        self.assertIn("records", table)
         self.assertIn("comunas", table)
         self.assertIn("indicadores", table)
 
@@ -414,7 +416,9 @@ class ChileHubTests(unittest.TestCase):
         self.assertIn("top_issue_reason", table)
         self.assertIn("top_issue_action", table)
         self.assertIn("top_issue_summary", table)
-        self.assertIn("dataset      mode      validation", table)
+        self.assertIn("dataset", table)
+        self.assertIn("mode", table)
+        self.assertIn("validation", table)
         self.assertIn("indicadores", table)
 
     def test_runtime_status_audit(self):
@@ -461,7 +465,9 @@ class ChileHubTests(unittest.TestCase):
         self.assertIn("top_issue_action=", table)
         self.assertIn("top_issue_summary=", table)
         self.assertIn(f"top_issue={EXPECTED_TOP_ISSUE}", table)
-        self.assertIn("dataset      mode      severity", table)
+        self.assertIn("dataset", table)
+        self.assertIn("mode", table)
+        self.assertIn("severity", table)
         self.assertIn("indicadores", table)
 
     def test_top_issue(self):
@@ -531,7 +537,11 @@ class ChileHubTests(unittest.TestCase):
         self.assertIn("top_issue_reason", snapshot)
         self.assertIn("top_issue_action", snapshot)
         self.assertIn("package_path", snapshot)
-        self.assertIn("dataset      mode      validation  build      current", snapshot)
+        self.assertIn("dataset", snapshot)
+        self.assertIn("mode", snapshot)
+        self.assertIn("validation", snapshot)
+        self.assertIn("build", snapshot)
+        self.assertIn("current", snapshot)
         self.assertIn("comunas", snapshot)
 
     def test_inventory_contains_artifact_types(self):
@@ -565,7 +575,9 @@ class ChileHubTests(unittest.TestCase):
     def test_inventory_table(self):
         table = self.hub.inventory_table()
         self.assertIn("chile-hub inventory", table)
-        self.assertIn("dataset      mode      records", table)
+        self.assertIn("dataset", table)
+        self.assertIn("mode", table)
+        self.assertIn("records", table)
         self.assertIn("comunas", table)
         self.assertIn("indicadores", table)
 
@@ -629,7 +641,9 @@ class ChileHubTests(unittest.TestCase):
         table = self.hub.health_table()
         self.assertIn("chile-hub health", table)
         self.assertIn(f"overall={self.health['overall_status']}", table)
-        self.assertIn("dataset      severity  mode", table)
+        self.assertIn("dataset", table)
+        self.assertIn("severity", table)
+        self.assertIn("mode", table)
         self.assertIn("comunas", table)
 
     def test_freshness_audit(self):
@@ -650,7 +664,9 @@ class ChileHubTests(unittest.TestCase):
     def test_freshness_audit_table(self):
         table = self.hub.freshness_audit_table()
         self.assertIn("chile-hub freshness audit", table)
-        self.assertIn("dataset      mode      build", table)
+        self.assertIn("dataset", table)
+        self.assertIn("mode", table)
+        self.assertIn("build", table)
         self.assertIn("indicadores", table)
 
     def test_bundle_summary(self):
@@ -745,7 +761,8 @@ class ChileHubTests(unittest.TestCase):
         table = self.hub.redistribution_table()
         self.assertIn("chile-hub redistribution", table)
         self.assertIn("ready=", table)
-        self.assertIn("dataset      status", table)
+        self.assertIn("dataset", table)
+        self.assertIn("status", table)
         self.assertIn("indicadores", table)
 
     def test_provenance_report(self):
@@ -765,7 +782,9 @@ class ChileHubTests(unittest.TestCase):
     def test_provenance_table(self):
         table = self.hub.provenance_table()
         self.assertIn("chile-hub provenance", table)
-        self.assertIn("dataset      mode      source", table)
+        self.assertIn("dataset", table)
+        self.assertIn("mode", table)
+        self.assertIn("source", table)
         self.assertIn("warnings", table)
         self.assertIn("comunas", table)
 
@@ -787,7 +806,9 @@ class ChileHubTests(unittest.TestCase):
     def test_drift_table(self):
         table = self.hub.drift_table()
         self.assertIn("chile-hub drift", table)
-        self.assertIn("dataset      drift      mode", table)
+        self.assertIn("dataset", table)
+        self.assertIn("drift", table)
+        self.assertIn("mode", table)
         self.assertIn("warnings", table)
         self.assertIn("indicadores", table)
 
@@ -1148,7 +1169,9 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_summary_table(self):
         result = self.run_cli("summary", "--format", "table")
         self.assertIn("chile-hub summary", result.stdout)
-        self.assertIn("dataset      mode      records", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("records", result.stdout)
         self.assertIn("comunas", result.stdout)
 
     def test_cli_path(self):
@@ -1243,7 +1266,9 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_inventory_table(self):
         result = self.run_cli("inventory", "--format", "table")
         self.assertIn("chile-hub inventory", result.stdout)
-        self.assertIn("dataset      mode      records", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("records", result.stdout)
         self.assertIn("comunas", result.stdout)
 
     def test_cli_snapshot(self):
@@ -1281,7 +1306,11 @@ class ChileHubCliTests(unittest.TestCase):
         self.assertIn("current_overall_status", result.stdout)
         self.assertIn("top_issue", result.stdout)
         self.assertIn("current_fresh", result.stdout)
-        self.assertIn("dataset      mode      validation  build      current", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("validation", result.stdout)
+        self.assertIn("build", result.stdout)
+        self.assertIn("current", result.stdout)
         self.assertIn("comunas", result.stdout)
 
     def test_cli_overview(self):
@@ -1305,7 +1334,9 @@ class ChileHubCliTests(unittest.TestCase):
         self.assertIn("top_issue_reason", result.stdout)
         self.assertIn("top_issue_action", result.stdout)
         self.assertIn("top_issue_summary", result.stdout)
-        self.assertIn("dataset      mode      validation", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("validation", result.stdout)
         self.assertIn("indicadores", result.stdout)
 
     def test_cli_health(self):
@@ -1320,7 +1351,9 @@ class ChileHubCliTests(unittest.TestCase):
         result = self.run_cli("health", "--format", "table")
         self.assertIn("chile-hub health", result.stdout)
         self.assertIn(f"overall={self.health['overall_status']}", result.stdout)
-        self.assertIn("dataset      severity  mode", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("severity", result.stdout)
+        self.assertIn("mode", result.stdout)
 
     def test_pipeline_status_script_text(self):
         result = self.run_script("scripts/pipeline_status.py")
@@ -1339,7 +1372,9 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_freshness_audit_table(self):
         result = self.run_cli("freshness-audit", "--format", "table")
         self.assertIn("chile-hub freshness audit", result.stdout)
-        self.assertIn("dataset      mode      build", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("build", result.stdout)
         self.assertIn("indicadores", result.stdout)
 
     def test_cli_runtime_status(self):
@@ -1358,7 +1393,9 @@ class ChileHubCliTests(unittest.TestCase):
         self.assertIn("top_issue_reason=", result.stdout)
         self.assertIn("top_issue_action=", result.stdout)
         self.assertIn("top_issue_summary=", result.stdout)
-        self.assertIn("dataset      mode      severity", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("severity", result.stdout)
         self.assertIn("indicadores", result.stdout)
 
     def test_cli_top_issue(self):
@@ -1420,7 +1457,8 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_redistribution_table(self):
         result = self.run_cli("redistribution", "--format", "table")
         self.assertIn("chile-hub redistribution", result.stdout)
-        self.assertIn("dataset      status", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("status", result.stdout)
         self.assertIn("indicadores", result.stdout)
 
     def test_cli_provenance(self):
@@ -1431,7 +1469,9 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_provenance_table(self):
         result = self.run_cli("provenance", "--format", "table")
         self.assertIn("chile-hub provenance", result.stdout)
-        self.assertIn("dataset      mode      source", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("mode", result.stdout)
+        self.assertIn("source", result.stdout)
         self.assertIn("comunas", result.stdout)
 
     def test_cli_drift(self):
@@ -1442,7 +1482,9 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_drift_table(self):
         result = self.run_cli("drift", "--format", "table")
         self.assertIn("chile-hub drift", result.stdout)
-        self.assertIn("dataset      drift      mode", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("drift", result.stdout)
+        self.assertIn("mode", result.stdout)
         self.assertIn("indicadores", result.stdout)
 
     def test_cli_export(self):
@@ -1458,7 +1500,8 @@ class ChileHubCliTests(unittest.TestCase):
     def test_cli_check_sources(self):
         result = self.run_cli("check-sources", "--timeout", "2", "--format", "table")
         self.assertIn("chile-hub check-sources", result.stdout)
-        self.assertIn("dataset      status", result.stdout)
+        self.assertIn("dataset", result.stdout)
+        self.assertIn("status", result.stdout)
 
     def test_cli_cross(self):
         result = self.run_cli("cross", "comunas", "censo_comunal", "--format", "json")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,52 @@
+"""Tests unitarios para el helper de renderizado _render.py.
+
+Estos tests verifican que render_table produzca texto plano sin ANSI y
+preserve el titulo, encabezados y celdas.
+"""
+
+from __future__ import annotations
+
+from chile_hub._render import render_table
+
+
+class TestRenderTable:
+    """Tests para render_table()."""
+
+    def test_returns_string_with_title(self):
+        output = render_table("chile-hub demo", ["a", "b"], [["1", "2"]])
+        assert isinstance(output, str)
+        assert "chile-hub demo" in output
+
+    def test_includes_headers_and_cells(self):
+        output = render_table("test", ["name", "value"], [["foo", "bar"]])
+        assert "name" in output
+        assert "value" in output
+        assert "foo" in output
+        assert "bar" in output
+
+    def test_no_ansi_escape_codes(self):
+        output = render_table("test", ["x"], [["y"]])
+        assert "\x1b[" not in output, f"Salida contiene ANSI: {output!r}"
+
+    def test_unicode_accented_names(self):
+        output = render_table(
+            "test",
+            ["comuna"],
+            [["Ñuñoa"]],
+        )
+        assert "Ñuñoa" in output
+
+    def test_empty_rows_does_not_crash(self):
+        output = render_table("empty", ["h"], [])
+        assert "empty" in output
+        assert isinstance(output, str)
+
+    def test_multiple_rows_preserve_order(self):
+        output = render_table(
+            "multi",
+            ["id"],
+            [["1"], ["2"], ["3"]],
+        )
+        # Verificar que los valores aparecen en la salida
+        for val in ("1", "2", "3"):
+            assert val in output

--- a/uv.lock
+++ b/uv.lock
@@ -343,13 +343,14 @@ wheels = [
 
 [[package]]
 name = "chile-hub"
-version = "1.14.0"
+version = "1.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },
     { name = "polars" },
     { name = "pyarrow" },
     { name = "requests" },
+    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -386,8 +387,8 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = "==1.9.4" },
     { name = "build", marker = "extra == 'dev'", specifier = "==1.5.0" },
     { name = "curl-cffi", marker = "extra == 'pipeline'", specifier = "==0.15.0" },
-    { name = "duckdb", marker = "extra == 'pipeline'", specifier = "==1.5.3" },
-    { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.155.6" },
+    { name = "duckdb", marker = "extra == 'pipeline'", specifier = "==1.5.4" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = "==6.155.7" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "openpyxl", marker = "extra == 'pipeline'", specifier = "==3.1.5" },
@@ -398,12 +399,13 @@ requires-dist = [
     { name = "polars", specifier = ">=1.41.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.6.0" },
     { name = "pyarrow", specifier = ">=24.0.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "==3.8.0" },
     { name = "python-semantic-release", marker = "extra == 'dev'", specifier = "==10.5.3" },
     { name = "requests", specifier = ">=2.34.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.17" },
+    { name = "rich", specifier = ">=14.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.18" },
     { name = "rutificador", marker = "extra == 'pipeline'", specifier = ">=1.5.8" },
     { name = "structlog", marker = "extra == 'dev'", specifier = "==26.1.0" },
     { name = "structlog", marker = "extra == 'pipeline'", specifier = "==26.1.0" },
@@ -691,44 +693,44 @@ wheels = [
 
 [[package]]
 name = "duckdb"
-version = "1.5.3"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/00/d579dcb2a536b6ea3a2563cdad6844f77d81a9b2d4b22a858097f2468acf/duckdb-1.5.3.tar.gz", hash = "sha256:df39428eb130faa35ae96fd35245bdeae6ecf43936250b116b5fead568eb9f16", size = 18026640, upload-time = "2026-05-20T11:55:31.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/4a/06a81e9e3c01634760073b6a8911fccee2e33b23569f479971f910228972/duckdb-1.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6ef8faf121d7b3ad95aab1c3ce31169a28be49da75abfa6099a1bec2e9a70189", size = 32575938, upload-time = "2026-05-20T11:53:56.365Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/ed/03ccf15147db7468f65891b5daa8489aa755d8cfcf75b24e7a4e4720e28c/duckdb-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dd00f70231951a619908471b7b6397232ff3be8ccd1f49a47f1a2ccac59eaba1", size = 17276167, upload-time = "2026-05-20T11:53:59.558Z" },
-    { url = "https://files.pythonhosted.org/packages/80/bd/ffc9e7a52731eec047dd49d45f029580dc8f3a6f8e8802a9e1c4138b0f8a/duckdb-1.5.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:50379b85f3a0a169478d54880ef8bf971ecaa85772d05eeaa617d720c7704741", size = 15425037, upload-time = "2026-05-20T11:54:01.894Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/5d/44209bcd4ad47feb84831edd3f269397e03167efbb86aee2d102b2f71252/duckdb-1.5.3-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d37650ec3ec8a951400ea12dc77edaea88e0baeda34801792776f95f2f922f4f", size = 19306975, upload-time = "2026-05-20T11:54:04.5Z" },
-    { url = "https://files.pythonhosted.org/packages/76/5c/bdb735011131c429cdb6d9e12e12fc8f1c8622158890d76a25819a58efc2/duckdb-1.5.3-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3fb3bad9bc1a3e101d66d33269142ce075dc3d75202ba74ba97d7e44c50b9cd", size = 21416979, upload-time = "2026-05-20T11:54:07.429Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c2/929666ff6d71b15b128c6f800d893fb5589c7b6430ff9ecdcd4e6d175bea/duckdb-1.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:fdc65233f0fcf9022e4c6a8ba2ba751a79deb291501073d660afb1aa9874051f", size = 13101915, upload-time = "2026-05-20T11:54:10.072Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/fc/a8a89c6c73f31c2b58c6abbc2f543e0b736042dd5ef7cc1784c24ec31428/duckdb-1.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:341a2672e2551ba51c95c1898f0ade983e76675e79038ccb16342c3d6cfb82d7", size = 32583465, upload-time = "2026-05-20T11:54:13.132Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f1/3423a2f523dd034e505d4a5dd8e210ae577212e152598dc13b6a5e736e1b/duckdb-1.5.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c9e8fa408705081160ede7ead238d16e73a36b8561b700f2bf2d650ae48e7b92", size = 17278520, upload-time = "2026-05-20T11:54:16.368Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/1a/7bf5ba1b7ea520557e6b2dbee1c85abab016bdac0c1779d9d0ef76c87300/duckdb-1.5.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:70a18f932cf6d87bd0e554613657a515c1443a1724aacfc7ec5137dd28698b03", size = 15424794, upload-time = "2026-05-20T11:54:19.891Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/16/ce4b1e386e45fab0268edbf1b85bace20e9437589e9edb2bd5f9a226fa44/duckdb-1.5.3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e80eb4d0fb59869cb2c7d7ef494c07fb92014fe8e77d96c170cd1ebc1488a708", size = 19306666, upload-time = "2026-05-20T11:54:22.77Z" },
-    { url = "https://files.pythonhosted.org/packages/99/1f/651f8453f26931e8061b7e27b3090f868868185814ecb9216d0bd71ec8ef/duckdb-1.5.3-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3248b49cd835ea322574bc6aac0ae7a83be85547f49d4f5f5777cb380ee6627f", size = 21418306, upload-time = "2026-05-20T11:54:25.616Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/64/e1ffebf010b1631a6fef8d1508f46d4eab3e97c18729af986bb796fa8452/duckdb-1.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:f4eff89c12c3a362efa012262e57b7b4ab904a7f79bad9178fe365510077abe8", size = 13101423, upload-time = "2026-05-20T11:54:28.107Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/42/b1d4e34f9658cc0e13d7aae581ab82643f50a548d5aee8767f0c587cc3a4/duckdb-1.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:75d13308c9da3ee431d1e72b8ab720aa74a1b3e9159d4124cb62435924496334", size = 13951740, upload-time = "2026-05-20T11:54:30.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/c4/2e34929b16c8d544ef664fad8f7f3a2a9db05746aae1e7c8c4ee3a8b23e4/duckdb-1.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ff11a457258148337ef9a392148a8cdbd1069b6c27c21958816c7b67fe6c542d", size = 32626494, upload-time = "2026-05-20T11:54:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/53/3af681793d03771365ae3e2215331151c196a3ac8193f613344840694671/duckdb-1.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fd25f533cb1b6b2c84cc767a9a9bab7769bb1aa44571a2a0bfc91ac3e4a38ac", size = 17301121, upload-time = "2026-05-20T11:54:36.928Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e2/c80af1eac2ab5d35fc2c372ef0a84668842e549fbbf7799277b3fccf3e39/duckdb-1.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:10960400ed60cdf0fe05bab2086fa8eb733889cb0ceca18d07ff9a00c0e0be7b", size = 15449283, upload-time = "2026-05-20T11:54:39.777Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/9a/c63af233c9f761bf5178a5210437e1bc6bcb30fa8a9073de6398cfb12c03/duckdb-1.5.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5f18e7561403054433706c187589e86629a7af09a7efc23a06a8b308e6acc68", size = 19332762, upload-time = "2026-05-20T11:54:42.51Z" },
-    { url = "https://files.pythonhosted.org/packages/21/cc/2d77af4fff86012f334ef82e6d54a995a86c8745e58074f1218ed7d25171/duckdb-1.5.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fb7516255a8764545e30f7efacea408cc847764a3027b3b0b3e7d1a7bebbc5c", size = 21453290, upload-time = "2026-05-20T11:54:45.272Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/5e/9bc4817a98feb4dab83e56f2245cd3a30d00ee646d4dec7926464e2b3f28/duckdb-1.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:8001eccbc28be244dfd04d708526f34ddd6460b47a8aeb5d0e39d6f7f9e3fe15", size = 13118308, upload-time = "2026-05-20T11:54:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/81/35/e3f32e4e53e2450ddb1db8312a17d1ce455d60cc4941b6ad2cfc908794b0/duckdb-1.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:6d2835e39bb6af73891f73c0f8d4324f98afe00d0b00c6d34b2a582c2256cbb0", size = 13927187, upload-time = "2026-05-20T11:54:50.584Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/a528eb09d8be51954c485864bd06753e616939a080cbc3dd4417e8c94a57/duckdb-1.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e75a6122c12579a99848517f6f00a4e342aebda3590c30fe9b5cc5f39d5e6afc", size = 32626254, upload-time = "2026-05-20T11:54:53.65Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/3c/1534c0a6db347c05eb7d0f6ecfb7aefbe74cbff398e4892a8fd1903a20e8/duckdb-1.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fd3963c1cb9d9567777f4a898a9dbe388a2fe9724681801b1e7d6d93eecf1b76", size = 17300917, upload-time = "2026-05-20T11:54:56.628Z" },
-    { url = "https://files.pythonhosted.org/packages/23/fa/beafb91e6e152d2161c4a9cbc472334c87607eb61ad7104b5a7fa8d8d7b1/duckdb-1.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3d5db8c0b55e072cf437948ebb5d7e23d7b9d03d905fa5f9145583e65aa447f7", size = 15449411, upload-time = "2026-05-20T11:54:59.089Z" },
-    { url = "https://files.pythonhosted.org/packages/50/0a/49b6fe04e2fcd63729eb607dadd44818dde77342a4f5ce086c6c92f1dd4d/duckdb-1.5.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ce80aed7a538422129a57eaca9141e3afb51f8bf562b1908b1576c9725b5b22", size = 19333120, upload-time = "2026-05-20T11:55:01.727Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4c/0907c3f76adb9dd90e67610b31e0304a35814e65c4c41a354a262c09b885/duckdb-1.5.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787df63824f07bf18022dbc3b8ca4b2bfab0ebe616464f55c6e8cd0f59ea762e", size = 21453266, upload-time = "2026-05-20T11:55:04.5Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/9c/d2f23a7803ddbbd9413f7572ecf66a15120ed5ced7ce5c73e698c1406b76/duckdb-1.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:bb5bb5dcdd09d62ee60f0ddbbef918e71cce304ffe28428b1131949d39ffaabf", size = 13118640, upload-time = "2026-05-20T11:55:07.389Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d5/7ba2316415bcdab6edd765bbbe35c2ca8a3800f2fe695cd70e3cdb997f09/duckdb-1.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:2fa17ecdd5d3db122836cb71bb93601c2106a3be883c17dffddc02fbf3fa7888", size = 13926409, upload-time = "2026-05-20T11:55:10.166Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/c2/d4b6f8a5e4d3bc25773be6da76a99d9661ebbf3552c007c460d2dd59dbf8/duckdb-1.5.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4bfa9a4dadf71e83e2c4eaca2f9421c82a54defecc1b0b4c0be95e2389dec4fe", size = 32636685, upload-time = "2026-05-20T11:55:13.158Z" },
-    { url = "https://files.pythonhosted.org/packages/42/58/e835c8298979d29db7a62cb5acc29e9b57aeaca7cdde2fcd3ac980f5cb18/duckdb-1.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aea7baf67ad7e1829ac76f67d7dcbd7fb1f57c3eb179d55ac30952df4709ae30", size = 17308134, upload-time = "2026-05-20T11:55:16.194Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/46/617b51363f5613418c8b224b3cce16b58e6dde80904566bec232579c1d4e/duckdb-1.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b0b4f088a65d77e1217ce5d7eff889e63fedc44281200d899ff47c84d8ff836", size = 15449891, upload-time = "2026-05-20T11:55:18.687Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/72/354146656e8d9ba3853d3a5ee80a481b8c5f70edfc3d5ae80a8c4479c967/duckdb-1.5.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe8d0c1f6a120aa03fa6e0d03897c71a1842e6cf7afd31d181348391f7108fe1", size = 19338499, upload-time = "2026-05-20T11:55:21.34Z" },
-    { url = "https://files.pythonhosted.org/packages/56/8f/65fc623b51448f2bfba1a9ec6ab3debb4664c0876c0113a5e782600b53ac/duckdb-1.5.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0405eae18ec6e8210a471c97dbfe87a7e4d605274b7fe572a1f276e92158f13", size = 21455828, upload-time = "2026-05-20T11:55:23.847Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/db/d0274cbe9f5fe219f77c0bdf900ac77103569e83c102a4225ce04cbc607d/duckdb-1.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:33ae08b3e818d7613d8936744b67718c2062c2f530376895bfd89efb51b81538", size = 13640011, upload-time = "2026-05-20T11:55:26.276Z" },
-    { url = "https://files.pythonhosted.org/packages/07/5d/8f1899b8bef291caf953992fcd6c24df9f29387a35645e58c2504a5ca473/duckdb-1.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:746433e49bbc667b4df283153415fbe37e9083e0eff6c3cd6e54de7536869cd4", size = 14411554, upload-time = "2026-05-20T11:55:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ee/69340af74a3aa21838f14c16a0dd3e58461896ccba41f6bc7f0a01536e23/duckdb-1.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ddd9533ce80f9b851bdd6276960a9286166514a9ceca43d5bc2f0d5842c490d", size = 32656177, upload-time = "2026-06-17T10:47:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/9da267ade389d4e7e533ac0c77b3a7041513a66efab93beb84f27627b0b8/duckdb-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360f2542d09759c3739400f8b787e29b43ba0da665c21756216291458bf6fc59", size = 17318966, upload-time = "2026-06-17T10:47:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/ad73c1a396288e443b18af50819448060b318c1e933305167c1d7f98a507/duckdb-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0cf932055061e544d3fa27cc6c147da25f3f681ee5980157fb55e77d6c2d9c63", size = 15467572, upload-time = "2026-06-17T10:47:36.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/06/2c52ce3b97c3f21111f3c98a2121ed002e33f86488f55098a37825af6d4a/duckdb-1.5.4-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2d58d39f5e65419cdc27e3875cba4a729a3bbf6bf4016aefb4a2a65335a1d42", size = 19344044, upload-time = "2026-06-17T10:47:38.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7d/5c0cc66fb90a1b14474eebb5ab535eacc51cb20b0e45358348b51c07abc9/duckdb-1.5.4-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9a10dc40469b9c0e458625d2a8359461a982c6151bb53ff259fea00c4695ad4", size = 21448215, upload-time = "2026-06-17T10:47:40.617Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/16c3ea201855cdfb7dde52ea3678d0536861cb485ffad46cf345436d658d/duckdb-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:3565550adbf160ef7a2ee3395470570182f11233983ad818bd7d5f9e349f92b2", size = 13132138, upload-time = "2026-06-17T10:47:43.085Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bb/7921dabd50daef3969f14cd8a5a14c24eee337db7914a462f2defa8add92/duckdb-1.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fb41d9cfccb7e44511eeeed263ae98143ca63bdb1ef84631ba637c314efa1b5", size = 32663142, upload-time = "2026-06-17T10:47:45.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/83/2137765eaba6a9aefe3bb9848ddaac7407fe3ba19b292f98b31f3b7ab27f/duckdb-1.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ba7b666bc9c78d6a930ee9f469024149f0c6a23fb7d2c3418aad6774339bec0", size = 17321485, upload-time = "2026-06-17T10:47:47.778Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/a02c1ee43fd7e8cf1fc2e3d377f3dcf9d4a3e58a4549557516e1866ff0da/duckdb-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9d9e6817fcbc09d2605a2c8c041ac7824d738d917c35a4d427e977647e1d7944", size = 15470820, upload-time = "2026-06-17T10:47:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/a243d30223b024bc6057abe472b002cff01e97efefb4d2f0b0dcc5aece0b/duckdb-1.5.4-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02dd9f9a6124069213f13e3a474c208028c472fe1acdae12b38761f954fe4fc6", size = 19341849, upload-time = "2026-06-17T10:47:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/a5d48de4771e2403a8ef26a20dc7457b1c8f7e398ff0caf9c0cad8805f89/duckdb-1.5.4-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccc7f2694d02b4763fee61021d45e12f7bc5743993686563957df0cef799fbae", size = 21451698, upload-time = "2026-06-17T10:47:54.653Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/8244d7741b4afae67775cf0cb0d4eb9e923a83110907e4801e17fa078480/duckdb-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:4c430e788d99b50854209bf2833ba36a45df75e57f86efb477046cd408bbd077", size = 13132643, upload-time = "2026-06-17T10:47:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/57/8169822a37f6dd7d561c567f9007e3cf04bf97bccb619afe90db849c0962/duckdb-1.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:e2dc8340cfb6006025a798c50f40126d6e945a1d2487be94667bb4166556ce7b", size = 13986386, upload-time = "2026-06-17T10:47:59.345Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
 ]
 
 [[package]]
@@ -862,15 +864,15 @@ wheels = [
 
 [[package]]
 name = "hypothesis"
-version = "6.155.6"
+version = "6.155.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/aa/9a91a4addf285702a98713da44b3581799539426436617bfb8914478c166/hypothesis-6.155.6.tar.gz", hash = "sha256:7569e1897690336c85d49d8391b49ec6ab83d951009515bfc29faebbac286cf5", size = 478038, upload-time = "2026-06-19T13:21:23.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz", hash = "sha256:d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea", size = 478291, upload-time = "2026-06-21T05:54:31.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a9/4c17e962c2e9cbc314bb579ed2e2b2da45d7b6b942aab6948d14d85abfea/hypothesis-6.155.6-py3-none-any.whl", hash = "sha256:a96d9a29f6bbc8ccac39dd84e140892da76765464929f401a4181b90c20c9ad1", size = 544521, upload-time = "2026-06-19T13:21:20.934Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f8/c151e196d4f397ed9436a071e52666c70a2f021138dea828b0a461e245db/hypothesis-6.155.7-py3-none-any.whl", hash = "sha256:9f634bdb1f9e9b8ab6ba09431cf2deedb750c96978125a6fb3c5a0f6c6db4131", size = 544762, upload-time = "2026-06-21T05:54:29.506Z" },
 ]
 
 [[package]]
@@ -1994,7 +1996,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.1.0"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2005,9 +2007,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -2237,27 +2239,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.17"
+version = "0.15.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
-    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
-    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
-    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
-    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
-    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
-    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Migra los 16 métodos `*_table()` de padding manual (`f"{valor:<11}"`) a `rich.Table` a través del nuevo helper `render_table()` sin ANSI.

- Promueve `rich>=14.0` a dependencia directa (ya estaba como transitiva)
- Crea `src/chile_hub/_render.py` con `render_table()`
- Migra todos los métodos `*_table()` de `core.py`
- Actualiza aserciones de padding manual en tests
- Añade `tests/test_render.py` (6 casos)

Closes #018

🤖 Generated with [Claude Code](https://claude.com/claude-code)