### PR TITLE
[codex] remove obsolete Node 24 forcing flag

### DIFF
--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -19,7 +19,6 @@ permissions:
   contents: read
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   PYTHON_VERSION: "3.13"
   PIPELINE_ARTIFACT: pipeline-output-${{ github.run_id }}
 


### PR DESCRIPTION
## What changed

- Removed the obsolete `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workflow environment setting.
- Kept the repository's intentional project/runtime Node version configuration unchanged.

## Why

GitHub-hosted Actions runners now use Node 24 by default. The pre-migration forcing flag is redundant and can cause workflow failures after the migration.

## Impact

JavaScript actions use the runner's default Node 24 runtime without an obsolete override. Application runtime behavior is unchanged.

## Validation

- Workflow YAML parsed successfully.
- `git diff --check` passed.
- Confirmed the forcing flag no longer appears in `.github/`.

## Rollback

Revert this commit.
