### PR TITLE
fix(ci): sync codeql-action init/analyze versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
       time: "09:30"
       timezone: America/Santiago
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     labels:
       - dependencies
       - github-actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: python
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:python


### PR DESCRIPTION
## Summary
- Ambas PRs de Dependabot (#21 init, #22 analyze) fallaban en el check "Analyze Python" de CodeQL con `Loaded a configuration file for version 'X', but running version 'Y'`.
- Causa raíz: `codeql.yml` fija `github/codeql-action/init` y `github/codeql-action/analyze` al mismo SHA, y ambos pasos deben correr siempre la misma versión. Dependabot trata `init` y `analyze` como referencias independientes y abrió una PR por cada una, así que fusionar cualquiera de las dos sola deja las versiones desincronizadas.
- Esta PR sube ambas referencias juntas a v4.36.3 y agrega un `group` en `dependabot.yml` para que futuros bumps de `github/codeql-action/*` lleguen en una sola PR.
- Cierra #21 y #22 (quedan reemplazadas por este cambio).

## Test plan
- [x] YAML válido (`yamllint`/`yaml.safe_load` sobre ambos archivos)
- [x] Pre-commit hooks pasan localmente
- [ ] CI de este repo (Pipeline Check, CodeQL) en verde

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>