### PR TITLE
chore: centralize hardcoded README facts (DRY single-source sync)

### DIFF
--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Check dataset registry/docs/contracts sync
         run: python scripts/check_companion_paths.py registry
 
+      - name: Check docs sync (README hardcoded facts)
+        run: python scripts/sync_docs.py --check
+
       - name: Fetch PR base commit for companion-path diff
         if: github.event_name == 'pull_request'
         run: git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
@@ -162,9 +165,9 @@ jobs:
       - name: Check build-synced files
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          if ! git diff --quiet -- index.html app.js; then
-            git diff -- index.html app.js
-            echo "::error::Build-synced files are stale. Run python src/build_dev_db.py and commit index.html/app.js."
+          if ! git diff --quiet -- index.html app.js README.md; then
+            git diff -- index.html app.js README.md
+            echo "::error::Build-synced files are stale. Run python src/build_dev_db.py and commit index.html/app.js/README.md."
             exit 1
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -798,8 +798,15 @@ protegido por un chequeo automatizado en vez de depender solo de buena voluntad.
 | Documentación de usuario por dataset | `docs/datasets/{nombre}.md` | `check_companion_paths.py registry` |
 | Criterios de inclusión/deprecación de datasets | `docs/dataset-inclusion-criteria.md` | — (revisión humana) |
 | Registro de funciones `validate_*()` | bloque `validations = {…}` en `build_dev_db.py` | `check_validation_registration.py` |
-| Versión del paquete | `pyproject.toml` (`[project] version`) | `python-semantic-release` (§7) |
+| Versión del paquete | `pyproject.toml` (`[project] version`) | `python-semantic-release` (§7), `scripts/sync_docs.py` propaga a README.md |
 | Inventario de clases de test | `tests/*.py` (no una tabla en prosa) | `grep '^class ' tests/*.py` (§8) |
+| Conteo de tests en README | `tests/test_*.py` (AST, no pytest — ver caveat parametrize en `doc_sync.py`) | `scripts/sync_docs.py --check` |
+| Conteo de ADRs en README | `docs/adr/*.md` | `scripts/sync_docs.py --check` |
+| Conteo de contratos en README | `contracts/datasets/*.schema.json` | `scripts/sync_docs.py --check` |
+| Badge "N capas" y resumen de auditoría legal en README | `data/dataset_catalog_config.json` / `data/normalized/redistribution_report.json` | `scripts/sync_docs.py --check` |
+| Resumen de salud (`ok`/`warn`/`error`) en README | `data/normalized/hub_health.json` | `scripts/sync_docs.py --check` |
+| Score de calidad (A-F) en README | `data/normalized/dataset_quality.json` | `scripts/sync_docs.py --check` |
+| Ejemplo de pin de versión en README | `pyproject.toml` vía `read_project_version()` | `scripts/sync_docs.py --check` |
 
 ### Mecanismo: `scripts/check_companion_paths.py`
 
@@ -820,6 +827,48 @@ Dos modos, ambos corren en `make doctor` y/o en el job `quality` de CI
 co-cambio real (un módulo más en `src/`, un nuevo doc que depende de un JSON),
 agrega la regla correspondiente a `COMPANION_RULES` en el mismo PR que la
 introduce — no dejes que el próximo drift se descubra a mano, como este.
+
+### Mecanismo: bloques delimitados + `scripts/sync_docs.py`
+
+`check_companion_paths.py` fuerza que se *toque* un archivo compañero, pero no
+verifica que su *contenido* siga siendo correcto. Para hechos de README.md que
+son derivables mecánicamente de un artefacto o del código (no prosa curada),
+`src/builders/doc_sync.py` + `src/builders/reports.py::sync_readme_layers_table()`
+regeneran el texto exacto dentro de un bloque delimitado por comentarios HTML
+(`<!-- START_X --> ... <!-- END_X -->`), usando el helper compartido
+`src/builders/io_utils.py::replace_delimited_block()`.
+
+- **Generación:** `make sync-docs`, o automáticamente al final de
+  `make build` (`build_dev_db.py::main()` llama a `sync_readme_layers_table()`
+  y `sync_all_docs()`).
+- **Verificación:** `python scripts/sync_docs.py --check` (no escribe, falla
+  con `SystemExit` si algún bloque quedaría desincronizado) corre en
+  `make doctor` y en el job `quality` de CI en cada push/PR/schedule — sin
+  dependencias nuevas, `doc_sync.py` es 100% stdlib.
+- **Caso especial — drift por datos *live*:** el chequeo de `quality` solo
+  detecta drift introducido por el propio PR (código, tests, ADRs, contratos,
+  `pyproject.toml`). Si los datos cambian sin que ningún PR toque código (p. ej.
+  `hub_health.json` se regenera con nuevos valores en el `schedule` diario), el
+  paso "Check build-synced files" del job `build-and-test` (solo
+  `schedule`/`workflow_dispatch`, después de un build real) compara
+  `index.html`, `app.js` **y `README.md`** contra el build recién generado.
+
+**Qué NO usa este mecanismo:** las tablas de prosa de `AGENTS.md` (§1 capas,
+§2/§3 extractores, §8 archivos de test) no se regeneran — son descripciones
+curadas editorialmente, no datos de una sola celda; automatizarlas exigiría
+mantener esa prosa duplicada dentro de un generador, sin eliminar el
+mantenimiento manual. Su protección es otra: los *conteos* que citan ("19
+capas", "9 archivos de test", "14 extractores en `make extract`") se detectan
+a ojo en revisión de PR, y su *completitud estructural* (¿falta una fila?) ya
+la cubre el gate de co-cambio de `check_companion_paths.py` de arriba.
+
+**Seguimiento recomendado, no implementado todavía** (mayor alcance):
+automatizar la tabla "CLI de referencia" de README.md introspeccionando
+`build_parser()` (requiere agregar `uv sync` al job `quality`, hoy sin
+dependencias); y automatizar la tabla de extractores de README.md, lo que
+requiere agregar primero un campo `"extractor"` a las 21 entradas de
+`data/dataset_catalog_config.json` (beneficio adicional: permitiría extender
+`check_companion_paths.py registry` para validar que ese archivo existe).
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PYTHON ?= $(if $(wildcard .venv/bin/python),.venv/bin/python,python3)
 VENV_DIR ?= .venv
 
-.PHONY: help bootstrap install-browsers doctor extract build verify verify-dev verify-readiness verify-publication verify-live verify-landing test coverage lint lint-fix format format-check package package-check package-smoke check refresh status catalog hub-list hub-summary hub-summary-table hub-example hub-artifacts hub-shared-artifacts hub-shared-artifacts-table hub-reports hub-reports-table hub-report hub-inventory hub-inventory-table hub-snapshot hub-snapshot-table hub-overview hub-overview-table hub-status hub-status-table hub-health hub-health-table hub-bundle hub-freshness-audit hub-freshness-audit-table hub-runtime-status hub-runtime-status-table hub-top-issue hub-top-issue-text hub-top-issue-table hub-packages hub-packages-table hub-package hub-package-verify hub-redistribution hub-redistribution-table hub-provenance hub-provenance-table hub-drift hub-drift-table hub-source-readiness hub-dataset-quality package-bundle clean-publishable docs-build docs-serve
+.PHONY: help bootstrap install-browsers doctor extract build verify verify-dev verify-readiness verify-publication verify-live verify-landing test coverage lint lint-fix format format-check package package-check package-smoke check refresh sync-docs status catalog hub-list hub-summary hub-summary-table hub-example hub-artifacts hub-shared-artifacts hub-shared-artifacts-table hub-reports hub-reports-table hub-report hub-inventory hub-inventory-table hub-snapshot hub-snapshot-table hub-overview hub-overview-table hub-status hub-status-table hub-health hub-health-table hub-bundle hub-freshness-audit hub-freshness-audit-table hub-runtime-status hub-runtime-status-table hub-top-issue hub-top-issue-text hub-top-issue-table hub-packages hub-packages-table hub-package hub-package-verify hub-redistribution hub-redistribution-table hub-provenance hub-provenance-table hub-drift hub-drift-table hub-source-readiness hub-dataset-quality package-bundle clean-publishable docs-build docs-serve
 
 help:
 	@printf "Targets disponibles:\n"
@@ -25,6 +25,7 @@ help:
 	@printf "  make package-smoke    Instala wheel local y prueba import + CLI\n"
 	@printf "  make check            Ejecuta build + verify + test + verify-landing\n"
 	@printf "  make refresh          Ejecuta extract + build + verify + test + verify-landing + lint + format-check\n"
+	@printf "  make sync-docs        Sincroniza hechos hardcodeados en README.md (ver AGENTS.md §12)\n"
 	@printf "  make status           Imprime resumen humano del pipeline\n"
 	@printf "  make catalog          Muestra dataset_catalog.json\n"
 	@printf "  make hub-list         Lista datasets via CLI\n"
@@ -84,6 +85,10 @@ doctor:
 	@$(PYTHON) -c "import duckdb, polars, pyarrow; from importlib.metadata import version; print('duckdb=' + duckdb.__version__); print('polars=' + polars.__version__); print('pyarrow=' + pyarrow.__version__); print('playwright=' + version('playwright'))"
 	@$(PYTHON) scripts/check_validation_registration.py
 	@$(PYTHON) scripts/check_companion_paths.py registry
+	@$(PYTHON) scripts/sync_docs.py --check
+
+sync-docs:
+	$(PYTHON) scripts/sync_docs.py
 
 extract:
 	PYTHONPATH=src $(PYTHON) src/extractors/subdere_extractor.py

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 [![License: MIT](https://img.shields.io/badge/Code%20License-MIT-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-3776AB.svg?style=flat&logo=python&logoColor=white)]()
 [![Formats](https://img.shields.io/badge/Formats-Parquet%20%7C%20DuckDB%20%7C%20SQLite%20%7C%20JSON%20%7C%20Excel-orange.svg)]()
+<!-- START_DATASET_BADGE -->
 [![Datasets](https://img.shields.io/badge/Datasets-19%20capas-16a34a.svg)]()
+<!-- END_DATASET_BADGE -->
 [![Comunas](https://img.shields.io/badge/Comunas-346-8b5cf6.svg)]()
 
 <p>
@@ -182,11 +184,11 @@ confiar ciegamente**. Los datos vienen con la evidencia que los respalda.
 | Pilar | Qué significa | Evidencia auditables |
 |:---|:---|:---|
 | **Procedencia documentada** | Cada dataset declara su fuente oficial exacta con URL directa al organismo público emisor (BCN, INE, MINEDUC, BCCh, MINSAL, datos.gob.cl). | [`provenance_report.md`](data/normalized/provenance_report.md) — fuente, modo y timestamp por capa |
-| **Auditoría legal explícita** | Licencia, atribución requerida y permiso de redistribución verificados dataset por dataset. **19 de 19 capas** pasan la auditoría (`ready`). | [`redistribution_report.md`](data/normalized/redistribution_report.md) + [`AGENTS.md §6`](AGENTS.md) |
+| **Auditoría legal explícita** | <!-- START_REDISTRIBUTION_SUMMARY -->Licencia, atribución requerida y permiso de redistribución verificados dataset por dataset. **19 de 19 capas** pasan la auditoría (`ready`).<!-- END_REDISTRIBUTION_SUMMARY --> | [`redistribution_report.md`](data/normalized/redistribution_report.md) + [`AGENTS.md §6`](AGENTS.md) |
 | **Pipeline que falla con estridencia** | Si una validación falla, el pipeline **aborta** — no publica datos corruptos, no emite advertencias silenciosas. | [`ADR-001`](docs/adr/ADR-001-pipeline-lineal-determinista.md) — fail-loud como decisión de arquitectura |
-| **Contratos de esquema verificados** | 21 contratos JSON Schema ([`contracts/datasets/`](contracts/datasets/)) definen columnas esperadas, tipos, claves primarias y cobertura. Se validan **en cada build** automáticamente. | [`ADR-005`](docs/adr/ADR-005-contratos-esquema-json-schema.md) + `contracts/datasets/*.json` |
-| **Salud transparente** | Dashboard público con severidad, frescura, cobertura, drift y degradación por dataset. 12 capas `ok`, 7 `warn`, 0 `error`. | [`hub_health.md`](data/normalized/hub_health.md) — estado completo actualizado en cada build |
-| **Calidad medida y pública** | Puntuación compuesta A-F por dataset: **promedio 94.2/100** (18 A, 1 B). Dimensiones: validación, contrato, madurez de fuente, frescura, cobertura, política de reúso. | [`dataset_quality.md`](data/normalized/dataset_quality.md) — scorecard completo |
+| **Contratos de esquema verificados** | <!-- START_CONTRACT_COUNT -->21 contratos JSON Schema ([`contracts/datasets/`](contracts/datasets/)) definen columnas esperadas, tipos, claves primarias y cobertura. Se validan **en cada build** automáticamente.<!-- END_CONTRACT_COUNT --> | [`ADR-005`](docs/adr/ADR-005-contratos-esquema-json-schema.md) + `contracts/datasets/*.json` |
+| **Salud transparente** | <!-- START_HEALTH_SUMMARY -->Dashboard público con severidad, frescura, cobertura, drift y degradación por dataset. 12 capas `ok`, 7 `warn`, 0 `error`.<!-- END_HEALTH_SUMMARY --> | [`hub_health.md`](data/normalized/hub_health.md) — estado completo actualizado en cada build |
+| **Calidad medida y pública** | <!-- START_QUALITY_SUMMARY -->Puntuación compuesta A-F por dataset: **promedio 94.2/100** (18 A, 1 B). Dimensiones: validación, contrato, madurez de fuente, frescura, cobertura, política de reúso.<!-- END_QUALITY_SUMMARY --> | [`dataset_quality.md`](data/normalized/dataset_quality.md) — scorecard completo |
 
 Cada pilar se audita automáticamente en cada ejecución del pipeline. Los reportes se
 regeneran en cada build — no son documentos estáticos mantenidos a mano. Para auditar
@@ -199,10 +201,12 @@ chile-hub health       # severidad, frescura, drift y cobertura
 
 ### Respaldo adicional
 
-- **583 tests** (`pytest --collect-only`, más scripts de verificación
-  del pipeline) que validan extracción, contratos e integridad de datos.
-- **5 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura
-  con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".
+<!-- START_TEST_COUNT -->
+- **597 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+<!-- END_TEST_COUNT -->
+<!-- START_ADR_COUNT -->
+- **5 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".
+<!-- END_ADR_COUNT -->
 - **Drift monitoreado:** todos los datasets bajo vigilancia de deriva de esquema; cualquier
   cambio en la fuente se detecta y registra ([`drift_report.md`](data/normalized/drift_report.md)).
 - **Trazabilidad completa:** cada build registra timestamp, versión de extractor y
@@ -508,13 +512,15 @@ df = comunas.join(censo, on="codigo_comuna")
 print(df.head())
 ```
 
+<!-- START_VERSION_PIN_EXAMPLE -->
 > **Versionado:** Para entornos productivos, fija la versión exacta en `requirements.txt`
 > (revisa el badge de PyPI al inicio de este README para la versión más reciente):
 > ```
-> chile-hub==1.19.11
+> chile-hub==1.19.12
 > ```
 > El bundle de datos se publica con cada release. La API del módulo `ChileHub` sigue
 > versionado semántico: cambios de interfaz pública solo en _major releases_.
+<!-- END_VERSION_PIN_EXAMPLE -->
 
 ### Desarrollo local del pipeline
 

--- a/scripts/sync_docs.py
+++ b/scripts/sync_docs.py
@@ -1,0 +1,45 @@
+import argparse
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from src.builders.doc_sync import sync_all_docs
+from src.builders.reports import sync_readme_layers_table
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sincroniza hechos hardcodeados en README.md con su fuente de verdad."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="No escribe; falla si algún bloque quedaría desincronizado.",
+    )
+    args = parser.parse_args()
+
+    changed = []
+    if sync_readme_layers_table(check_only=args.check):
+        changed.append("sync_readme_layers_table")
+    changed += sync_all_docs(check_only=args.check)
+
+    if args.check:
+        if changed:
+            raise SystemExit(
+                "ERROR: bloques de README.md desincronizados: "
+                + ", ".join(changed)
+                + " — corre 'make sync-docs' y commitea el resultado."
+            )
+        print("sync_docs --check: README.md al día")
+    else:
+        if changed:
+            print("sync_docs: bloques actualizados: " + ", ".join(changed))
+        else:
+            print("sync_docs: sin cambios")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_release_artifact_version.py
+++ b/scripts/sync_release_artifact_version.py
@@ -23,23 +23,21 @@ from src.builders.artifacts import (
     write_publishable_bundle_sha256,
     write_publishable_bundle_zip,
 )
-from src.builders.io_utils import write_json_atomic
+from src.builders.io_utils import read_project_version, write_json_atomic
 from src.builders.landing import sync_landing_metadata
 
 NORMALIZED_DIR = ROOT_DIR / "data" / "normalized"
 
 
 def load_project_metadata() -> tuple[str, str]:
+    version = read_project_version(str(ROOT_DIR))
     with open(ROOT_DIR / "pyproject.toml", "rb") as f:
         pyproject_data = tomllib.load(f)
-    version = pyproject_data.get("project", {}).get("version")
     public_site_url = (
         pyproject_data.get("tool", {})
         .get("chile_hub", {})
         .get("public_site_url", "https://tooltician.com/chile-hub/")
     )
-    if not version:
-        raise SystemExit("pyproject.toml is missing project.version")
     return version, public_site_url
 
 

--- a/src/build_dev_db.py
+++ b/src/build_dev_db.py
@@ -58,6 +58,7 @@ from src.builders.datasets import (  # noqa: E402
     build_perfil_territorial_comunal,
     derive_geography_layers,
 )
+from src.builders.doc_sync import sync_all_docs  # noqa: E402
 from src.builders.formats import (  # noqa: E402
     build_duckdb,
     build_excel,
@@ -860,6 +861,7 @@ def main():
     )
     _generate_reports(pipeline_metadata, previous_pipeline_metadata, metadata_output)
     sync_readme_layers_table()
+    sync_all_docs()
     log.info("build_complete")
 
 

--- a/src/builders/__init__.py
+++ b/src/builders/__init__.py
@@ -12,6 +12,8 @@ módulos cohesivos:
 - `datasets`: builders de datasets derivados (perfil territorial, capas geográficas).
 - `catalog`: escritura del metadata del pipeline y del catálogo de datasets.
 - `landing`: sincronización de metadatos JSON-LD en la landing page.
+- `doc_sync`: sincroniza hechos hardcodeados (conteos, versión, salud, calidad)
+  con README.md — ver AGENTS.md §12.
 
 `build_dev_db.py` re-exporta los nombres públicos para mantener
 compatibilidad con scripts externos (`scripts/verify_pipeline.py`) y tests.

--- a/src/builders/doc_sync.py
+++ b/src/builders/doc_sync.py
@@ -1,0 +1,166 @@
+"""Sincroniza hechos "variables" hardcodeados en README.md con su fuente de verdad.
+
+Cada función lee un hecho derivado del estado real del proyecto (conteo de
+tests, de ADRs, de contratos, versión del paquete, salud y calidad del hub) y
+reemplaza el bloque delimitado correspondiente en README.md vía
+``replace_delimited_block``. Ver AGENTS.md §12 para la tabla completa de
+propietarios canónicos y dónde corre la generación/verificación.
+"""
+
+import ast
+import os
+
+from src.builders._shared import DATASET_CATALOG_CONFIG, NORMALIZED_DIR, ROOT_DIR
+from src.builders.io_utils import read_json_if_exists, read_project_version, replace_delimited_block
+
+README_PATH = os.path.join(ROOT_DIR, "README.md")
+TESTS_DIR = os.path.join(ROOT_DIR, "tests")
+ADR_DIR = os.path.join(ROOT_DIR, "docs", "adr")
+CONTRACTS_DIR = os.path.join(ROOT_DIR, "contracts", "datasets")
+
+GRADE_ORDER = ["A", "B", "C", "D", "F"]
+
+
+def _count_test_functions():
+    """Cuenta funciones `test_*` en tests/test_*.py vía AST (sin correr pytest).
+
+    Coincide con `pytest --collect-only` mientras la suite no use
+    `@pytest.mark.parametrize` (verificado: 0 usos hoy). Si se introduce
+    parametrize, este conteo subestimará el real — en ese caso migrar a
+    invocar `pytest --collect-only -q` (requiere pytest instalado).
+    """
+    total = 0
+    for name in sorted(os.listdir(TESTS_DIR)):
+        if not (name.startswith("test_") and name.endswith(".py")):
+            continue
+        path = os.path.join(TESTS_DIR, name)
+        with open(path, "r", encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+                total += 1
+    return total
+
+
+def sync_readme_test_count(check_only=False):
+    count = _count_test_functions()
+    body = (
+        f"- **{count} tests** (`pytest --collect-only`) que validan extracción, "
+        "contratos e integridad de datos."
+    )
+    return replace_delimited_block(
+        README_PATH, "TEST_COUNT", body, check_only=check_only, separator="\n"
+    )
+
+
+def sync_readme_adr_count(check_only=False):
+    count = len([n for n in os.listdir(ADR_DIR) if n.startswith("ADR-") and n.endswith(".md")])
+    body = (
+        f"- **{count} ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión "
+        'de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", '
+        'sino el "por qué".'
+    )
+    return replace_delimited_block(
+        README_PATH, "ADR_COUNT", body, check_only=check_only, separator="\n"
+    )
+
+
+def sync_readme_contract_count(check_only=False):
+    count = len([n for n in os.listdir(CONTRACTS_DIR) if n.endswith(".schema.json")])
+    body = (
+        f"{count} contratos JSON Schema ([`contracts/datasets/`](contracts/datasets/)) "
+        "definen columnas esperadas, tipos, claves primarias y cobertura. Se validan "
+        "**en cada build** automáticamente."
+    )
+    return replace_delimited_block(
+        README_PATH, "CONTRACT_COUNT", body, check_only=check_only, separator=""
+    )
+
+
+def sync_readme_dataset_badge(check_only=False):
+    built_count = len([d for d in DATASET_CATALOG_CONFIG.values() if d.get("outputs")])
+    body = (
+        f"[![Datasets](https://img.shields.io/badge/Datasets-{built_count}%20capas-16a34a.svg)]()"
+    )
+    return replace_delimited_block(
+        README_PATH, "DATASET_BADGE", body, check_only=check_only, separator="\n"
+    )
+
+
+def sync_readme_version_pin_example(check_only=False):
+    version = read_project_version(ROOT_DIR)
+    body = (
+        "> **Versionado:** Para entornos productivos, fija la versión exacta en `requirements.txt`\n"
+        "> (revisa el badge de PyPI al inicio de este README para la versión más reciente):\n"
+        "> ```\n"
+        f"> chile-hub=={version}\n"
+        "> ```\n"
+        "> El bundle de datos se publica con cada release. La API del módulo `ChileHub` sigue\n"
+        "> versionado semántico: cambios de interfaz pública solo en _major releases_."
+    )
+    return replace_delimited_block(
+        README_PATH, "VERSION_PIN_EXAMPLE", body, check_only=check_only, separator="\n"
+    )
+
+
+def sync_readme_redistribution_summary(check_only=False):
+    report = read_json_if_exists(os.path.join(NORMALIZED_DIR, "redistribution_report.json"))
+    if report is None:
+        return False
+    ready = report.get("ready_count", 0)
+    total = report.get("dataset_count", 0)
+    body = (
+        "Licencia, atribución requerida y permiso de redistribución verificados dataset por "
+        f"dataset. **{ready} de {total} capas** pasan la auditoría (`ready`)."
+    )
+    return replace_delimited_block(
+        README_PATH, "REDISTRIBUTION_SUMMARY", body, check_only=check_only, separator=""
+    )
+
+
+def sync_readme_health_summary(check_only=False):
+    health = read_json_if_exists(os.path.join(NORMALIZED_DIR, "hub_health.json"))
+    if health is None:
+        return False
+    ok = health.get("ok_count", 0)
+    warn = health.get("warn_count", 0)
+    error = health.get("error_count", 0)
+    body = (
+        "Dashboard público con severidad, frescura, cobertura, drift y degradación por dataset. "
+        f"{ok} capas `ok`, {warn} `warn`, {error} `error`."
+    )
+    return replace_delimited_block(
+        README_PATH, "HEALTH_SUMMARY", body, check_only=check_only, separator=""
+    )
+
+
+def sync_readme_quality_summary(check_only=False):
+    quality = read_json_if_exists(os.path.join(NORMALIZED_DIR, "dataset_quality.json"))
+    if quality is None:
+        return False
+    average = quality.get("average_score", 0)
+    distribution = quality.get("grade_distribution", {})
+    grades = ", ".join(f"{distribution[g]} {g}" for g in GRADE_ORDER if distribution.get(g, 0) > 0)
+    body = (
+        f"Puntuación compuesta A-F por dataset: **promedio {average}/100** ({grades}). "
+        "Dimensiones: validación, contrato, madurez de fuente, frescura, cobertura, política de reúso."
+    )
+    return replace_delimited_block(
+        README_PATH, "QUALITY_SUMMARY", body, check_only=check_only, separator=""
+    )
+
+
+SYNC_FUNCS = [
+    sync_readme_test_count,
+    sync_readme_adr_count,
+    sync_readme_contract_count,
+    sync_readme_dataset_badge,
+    sync_readme_version_pin_example,
+    sync_readme_redistribution_summary,
+    sync_readme_health_summary,
+    sync_readme_quality_summary,
+]
+
+
+def sync_all_docs(check_only=False):
+    return [fn.__name__ for fn in SYNC_FUNCS if fn(check_only=check_only)]

--- a/src/builders/io_utils.py
+++ b/src/builders/io_utils.py
@@ -7,6 +7,9 @@ temporal y lo renombran (`os.replace`) para garantizar escritura atómica.
 import hashlib
 import json
 import os
+import re
+
+import tomllib
 
 
 def write_json_atomic(data, path, **kwargs):
@@ -35,3 +38,64 @@ def compute_sha256(path):
         for chunk in iter(lambda: f.read(65536), b""):
             hasher.update(chunk)
     return hasher.hexdigest()
+
+
+def read_json_if_exists(path):
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def read_project_version(root_dir):
+    pyproject_path = os.path.join(root_dir, "pyproject.toml")
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = tomllib.load(f)
+    version = pyproject_data.get("project", {}).get("version")
+    if not version:
+        raise SystemExit(f"{pyproject_path} no tiene [project] version")
+    return version
+
+
+def replace_delimited_block(file_path, block_name, new_body, check_only=False, separator="\n\n"):
+    """Reemplaza el contenido entre marcadores HTML delimitados por nombre.
+
+    Un marcador ausente es un error duro (a diferencia de un archivo fuente
+    que todavía no existe en un checkout fresco): indica un typo o un bloque
+    borrado a mano, no un estado esperado del pipeline.
+
+    ``separator`` controla qué va entre los marcadores y el cuerpo:
+    ``"\\n\\n"`` (default) para bloques que son su propio párrafo (ej. la
+    tabla de datasets); ``"\\n"`` para contenido que debe quedar en su propia
+    línea sin línea en blanco (ej. un ítem de lista o un badge, para no
+    romper la lista/fila contigua); ``""`` para contenido que debe quedar en
+    la MISMA línea que los marcadores (obligatorio dentro de una celda de
+    tabla Markdown, que no puede tener saltos de línea reales).
+    """
+    start_marker = f"<!-- START_{block_name} -->"
+    end_marker = f"<!-- END_{block_name} -->"
+    with open(file_path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    if start_marker not in content or end_marker not in content:
+        raise SystemExit(
+            f"ERROR: {file_path} no tiene el bloque delimitado '{block_name}' "
+            f"({start_marker} / {end_marker})"
+        )
+
+    new_block = f"{start_marker}{separator}{new_body}{separator}{end_marker}"
+    pattern = re.escape(start_marker) + r".*?" + re.escape(end_marker)
+    # Reemplazo vía función (no string) para que re.sub no interprete
+    # backslashes o \g<...> del cuerpo generado como backreferences.
+    new_content = re.sub(pattern, lambda _match: new_block, content, count=1, flags=re.DOTALL)
+
+    if new_content == content:
+        return False
+    if check_only:
+        return True
+
+    tmp_path = file_path + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(new_content)
+    os.replace(tmp_path, file_path)
+    return True

--- a/src/builders/reports.py
+++ b/src/builders/reports.py
@@ -7,7 +7,6 @@ calidad de datasets) y las escriben a `data/normalized/` de forma atómica.
 
 import json
 import os
-import re
 from datetime import datetime
 
 from src.builders._shared import (
@@ -17,7 +16,7 @@ from src.builders._shared import (
     ROOT_DIR,
     UTC,
 )
-from src.builders.io_utils import write_json_atomic
+from src.builders.io_utils import replace_delimited_block, write_json_atomic
 
 
 def write_hub_health_json(health):
@@ -841,7 +840,7 @@ def _format_record_count(record_count, expected_count, coverage_note):
     return str(record_count)
 
 
-def sync_readme_layers_table():
+def sync_readme_layers_table(check_only=False):
     """Regenera la tabla de capas del README desde los reportes máquina.
 
     Lee ``hub_health.json`` (modo, cobertura) y ``dataset_status.json``
@@ -850,13 +849,15 @@ def sync_readme_layers_table():
     en ``README.md``.
 
     Si los reportes no existen (p. ej. build no ejecutado), no modifica nada.
+    Con ``check_only=True`` no escribe — solo retorna si el bloque cambiaría
+    (usado por ``scripts/sync_docs.py --check``).
     """
     health_path = os.path.join(NORMALIZED_DIR, "hub_health.json")
     status_path = os.path.join(NORMALIZED_DIR, "dataset_status.json")
 
     if not os.path.exists(health_path) or not os.path.exists(status_path):
         print("README sync: omitido (reportes no encontrados)")
-        return
+        return False
 
     with open(health_path, "r", encoding="utf-8") as f:
         health = json.load(f)
@@ -984,17 +985,13 @@ def sync_readme_layers_table():
     table_block = "\n".join(table_lines) + "\n\n" + legend
 
     readme_path = os.path.join(ROOT_DIR, "README.md")
-    with open(readme_path, "r", encoding="utf-8") as f:
-        content = f.read()
+    changed = replace_delimited_block(
+        readme_path, "DATASET_TABLE", table_block, check_only=check_only
+    )
 
-    pattern = r"<!-- START_DATASET_TABLE -->.*?<!-- END_DATASET_TABLE -->"
-    replacement = f"<!-- START_DATASET_TABLE -->\n\n{table_block}\n\n<!-- END_DATASET_TABLE -->"
-
-    new_content = re.sub(pattern, replacement, content, flags=re.DOTALL)
-
-    if new_content != content:
-        with open(readme_path, "w", encoding="utf-8") as f:
-            f.write(new_content)
-        print("README sync: tabla de capas regenerada desde hub_health.json + dataset_status.json")
+    if changed:
+        verb = "cambiaría" if check_only else "regenerada"
+        print(f"README sync: tabla de capas {verb} desde hub_health.json + dataset_status.json")
     else:
         print("README sync: tabla de capas sin cambios")
+    return changed

--- a/tests/test_pipeline_logic.py
+++ b/tests/test_pipeline_logic.py
@@ -2717,6 +2717,263 @@ class SyncLandingMetadataTests(unittest.TestCase):
                 landing.sync_landing_metadata("https://example.cl/chile-hub/")
 
 
+class ReplaceDelimitedBlockTests(unittest.TestCase):
+    """Tests para io_utils.replace_delimited_block(): el helper compartido que
+    generaliza el patrón de sync_readme_layers_table() a cualquier bloque
+    delimitado (ver AGENTS.md §12, mecanismo de bloques delimitados)."""
+
+    def _write(self, tmpdir, content):
+        path = Path(tmpdir) / "doc.md"
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_missing_marker_raises_system_exit(self):
+        from src.builders.io_utils import replace_delimited_block
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._write(tmpdir, "sin marcadores aquí")
+            with self.assertRaises(SystemExit):
+                replace_delimited_block(str(path), "FOO", "nuevo cuerpo")
+
+    def test_check_only_does_not_write(self):
+        from src.builders.io_utils import replace_delimited_block
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._write(tmpdir, "<!-- START_FOO -->\n\nviejo\n\n<!-- END_FOO -->")
+            changed = replace_delimited_block(str(path), "FOO", "nuevo", check_only=True)
+            self.assertTrue(changed)
+            self.assertIn("viejo", path.read_text(encoding="utf-8"))
+
+    def test_writes_and_returns_true_when_body_changes(self):
+        from src.builders.io_utils import replace_delimited_block
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._write(
+                tmpdir, "antes\n<!-- START_FOO -->\n\nviejo\n\n<!-- END_FOO -->\ndespués"
+            )
+            changed = replace_delimited_block(str(path), "FOO", "nuevo")
+            self.assertTrue(changed)
+            content = path.read_text(encoding="utf-8")
+            self.assertIn("nuevo", content)
+            self.assertNotIn("viejo", content)
+            self.assertIn("antes", content)
+            self.assertIn("después", content)
+
+    def test_returns_false_and_does_not_touch_file_when_unchanged(self):
+        from src.builders.io_utils import replace_delimited_block
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._write(tmpdir, "<!-- START_FOO -->\n\nigual\n\n<!-- END_FOO -->")
+            mtime_before = path.stat().st_mtime_ns
+            changed = replace_delimited_block(str(path), "FOO", "igual")
+            self.assertFalse(changed)
+            self.assertEqual(path.stat().st_mtime_ns, mtime_before)
+
+    def test_inline_separator_keeps_same_line(self):
+        from src.builders.io_utils import replace_delimited_block
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._write(tmpdir, "| celda <!-- START_FOO -->viejo<!-- END_FOO --> | otra |")
+            replace_delimited_block(str(path), "FOO", "nuevo", separator="")
+            content = path.read_text(encoding="utf-8")
+            self.assertEqual(
+                content,
+                "| celda <!-- START_FOO -->nuevo<!-- END_FOO --> | otra |",
+            )
+
+    def test_body_with_backslashes_is_not_interpreted_as_backreference(self):
+        """re.sub interpretaría \\1/\\g<...> en un string de reemplazo — el
+        helper usa una función de reemplazo para evitar ese bug de forma
+        estructural, no por casualidad. Este test lo fija como regresión."""
+        from src.builders.io_utils import replace_delimited_block
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._write(tmpdir, "<!-- START_FOO -->\n\nviejo\n\n<!-- END_FOO -->")
+            replace_delimited_block(str(path), "FOO", r"C:\Users\1 y \g<name>", separator="")
+            content = path.read_text(encoding="utf-8")
+            self.assertIn(r"C:\Users\1 y \g<name>", content)
+
+
+class DocSyncTests(unittest.TestCase):
+    """Tests para src/builders/doc_sync.py: sincroniza hechos hardcodeados de
+    README.md (conteo de tests/ADRs/contratos, badge, pin de versión, salud,
+    calidad, redistribución) con su fuente de verdad. Ver AGENTS.md §12."""
+
+    def _readme(self, tmpdir, *blocks):
+        lines = ["# README de prueba", ""]
+        for name in blocks:
+            lines += [f"<!-- START_{name} -->", "placeholder", f"<!-- END_{name} -->"]
+        path = Path(tmpdir) / "README.md"
+        path.write_text("\n".join(lines), encoding="utf-8")
+        return path
+
+    def test_test_count_matches_ast_function_count(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tests_dir = Path(tmpdir) / "tests"
+            tests_dir.mkdir()
+            (tests_dir / "test_a.py").write_text(
+                "def test_one():\n    pass\n\n\ndef test_two():\n    pass\n", encoding="utf-8"
+            )
+            (tests_dir / "test_b.py").write_text(
+                "def test_three():\n    pass\n\n\ndef helper():\n    pass\n", encoding="utf-8"
+            )
+            (tests_dir / "not_a_test.py").write_text(
+                "def test_ignored():\n    pass\n", encoding="utf-8"
+            )
+            readme = self._readme(tmpdir, "TEST_COUNT")
+
+            with (
+                patch.object(doc_sync, "TESTS_DIR", str(tests_dir)),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                changed = doc_sync.sync_readme_test_count()
+
+            self.assertTrue(changed)
+            self.assertIn("**3 tests**", readme.read_text(encoding="utf-8"))
+
+    def test_adr_and_contract_counts(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adr_dir = Path(tmpdir) / "adr"
+            adr_dir.mkdir()
+            (adr_dir / "ADR-001-x.md").write_text("x", encoding="utf-8")
+            (adr_dir / "ADR-002-y.md").write_text("y", encoding="utf-8")
+            (adr_dir / "README.md").write_text("no cuenta")
+
+            contracts_dir = Path(tmpdir) / "contracts"
+            contracts_dir.mkdir()
+            (contracts_dir / "comunas.schema.json").write_text("{}", encoding="utf-8")
+
+            readme = self._readme(tmpdir, "ADR_COUNT", "CONTRACT_COUNT")
+
+            with (
+                patch.object(doc_sync, "ADR_DIR", str(adr_dir)),
+                patch.object(doc_sync, "CONTRACTS_DIR", str(contracts_dir)),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                doc_sync.sync_readme_adr_count()
+                doc_sync.sync_readme_contract_count()
+
+            content = readme.read_text(encoding="utf-8")
+            self.assertIn("**2 ADRs**", content)
+            self.assertIn("1 contratos JSON Schema", content)
+
+    def test_health_and_quality_summary_from_fixtures(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized_dir = Path(tmpdir) / "normalized"
+            normalized_dir.mkdir()
+            (normalized_dir / "hub_health.json").write_text(
+                json.dumps({"ok_count": 5, "warn_count": 2, "error_count": 0}), encoding="utf-8"
+            )
+            (normalized_dir / "dataset_quality.json").write_text(
+                json.dumps(
+                    {
+                        "average_score": 91.0,
+                        "grade_distribution": {"A": 4, "B": 1, "C": 0, "D": 0, "F": 0},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            readme = self._readme(tmpdir, "HEALTH_SUMMARY", "QUALITY_SUMMARY")
+
+            with (
+                patch.object(doc_sync, "NORMALIZED_DIR", str(normalized_dir)),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                doc_sync.sync_readme_health_summary()
+                doc_sync.sync_readme_quality_summary()
+
+            content = readme.read_text(encoding="utf-8")
+            self.assertIn("5 capas `ok`, 2 `warn`, 0 `error`", content)
+            self.assertIn("promedio 91.0/100", content)
+            self.assertIn("4 A, 1 B", content)
+
+    def test_health_summary_returns_false_when_artifact_missing(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized_dir = Path(tmpdir) / "normalized"
+            normalized_dir.mkdir()
+            readme = self._readme(tmpdir, "HEALTH_SUMMARY")
+
+            with (
+                patch.object(doc_sync, "NORMALIZED_DIR", str(normalized_dir)),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                changed = doc_sync.sync_readme_health_summary()
+
+            self.assertFalse(changed)
+            self.assertIn("placeholder", readme.read_text(encoding="utf-8"))
+
+    def test_version_pin_example_reads_pyproject(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "pyproject.toml").write_text(
+                '[project]\nname = "x"\nversion = "9.9.9"\n', encoding="utf-8"
+            )
+            readme = self._readme(tmpdir, "VERSION_PIN_EXAMPLE")
+
+            with (
+                patch.object(doc_sync, "ROOT_DIR", tmpdir),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                doc_sync.sync_readme_version_pin_example()
+
+            self.assertIn("chile-hub==9.9.9", readme.read_text(encoding="utf-8"))
+
+    def test_dataset_badge_counts_only_datasets_with_outputs(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            readme = self._readme(tmpdir, "DATASET_BADGE")
+            fake_catalog = {
+                "comunas": {"outputs": {"parquet": "x"}},
+                "empresas": {"outputs": {"parquet": "y"}},
+                "candidato": {"outputs": {}},
+            }
+
+            with (
+                patch.object(doc_sync, "DATASET_CATALOG_CONFIG", fake_catalog),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                doc_sync.sync_readme_dataset_badge()
+
+            self.assertIn("Datasets-2%20capas", readme.read_text(encoding="utf-8"))
+
+    def test_redistribution_summary_from_fixture(self):
+        from src.builders import doc_sync
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized_dir = Path(tmpdir) / "normalized"
+            normalized_dir.mkdir()
+            (normalized_dir / "redistribution_report.json").write_text(
+                json.dumps({"ready_count": 17, "dataset_count": 19}), encoding="utf-8"
+            )
+            readme = self._readme(tmpdir, "REDISTRIBUTION_SUMMARY")
+
+            with (
+                patch.object(doc_sync, "NORMALIZED_DIR", str(normalized_dir)),
+                patch.object(doc_sync, "README_PATH", str(readme)),
+            ):
+                doc_sync.sync_readme_redistribution_summary()
+
+            self.assertIn("**17 de 19 capas**", readme.read_text(encoding="utf-8"))
+
+    def test_sync_all_docs_runs_every_function_without_error(self):
+        """Smoke test contra el README real: confirma que las 8 funciones
+        corren sin lanzar excepciones y que check_only nunca escribe."""
+        from src.builders import doc_sync
+
+        changed = doc_sync.sync_all_docs(check_only=True)
+        self.assertIsInstance(changed, list)
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Summary

- Several README.md facts (test count, ADR/contract counts, health/quality
  summaries, dataset-count badge, version pin example) were hand-maintained
  prose with no owner keeping them in sync. The version pin was already
  stale again within a day of being fixed by hand — concrete proof of the
  drift problem.
- Generalizes the existing `sync_readme_layers_table()` marker-block
  pattern into `src/builders/io_utils.py::replace_delimited_block()` +
  `src/builders/doc_sync.py` (one function per fact, each reading its real
  source of truth).
- Wired into `make sync-docs` (new), `make doctor`, the tail of
  `build_dev_db.py::main()`, and CI: `scripts/sync_docs.py --check` runs in
  the `quality` job on every push/PR (no new CI dependencies — 100%
  stdlib), and the existing schedule-only "Check build-synced files" gate
  now also covers `README.md`.
- Refactors `scripts/sync_release_artifact_version.py` to read the version
  through the same new `read_project_version()` helper instead of
  duplicating the `tomllib` read.
- Documents the mechanism in `AGENTS.md §12`, including what's explicitly
  *not* automated (AGENTS.md's own curated prose tables) and why.
- Deferred as a follow-up (needs a registry schema change / new CI
  dependency): automating the CLI reference table and the extractor table.

## Test plan

- [x] `make doctor` passes (includes the new `sync_docs.py --check` gate).
- [x] `pytest` — 597 tests pass (14 new, covering `replace_delimited_block`
      and every `doc_sync.py` function via fixtures).
- [x] `ruff check` / `ruff format --check` clean.
- [x] Manually broke a synced value, confirmed `--check` fails with a clear
      message, confirmed `make sync-docs` fixes it and `--check` passes again.
- [x] Confirmed `scripts/sync_release_artifact_version.py` still resolves
      the correct version after the refactor.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)