### PR TITLE
feat(ci): publica GeoParquet comunal bajo demanda

### DIFF
--- a/.github/workflows/geometria-comunal.yml
+++ b/.github/workflows/geometria-comunal.yml
@@ -1,0 +1,130 @@
+name: Refresh Candidate Comunal Geometry
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  PYTHON_VERSION: "3.13"
+
+concurrency:
+  group: geometria-comunal
+  cancel-in-progress: false
+
+jobs:
+  refresh-geometry:
+    name: Build and publish candidate GeoParquet
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install locked dependencies
+        run: |
+          uv lock --locked
+          uv sync --extra pipeline --extra dev --locked
+
+      - name: Build candidate GeoParquet
+        run: uv run python scripts/build_geometria_comunal.py
+
+      - name: Validate candidate GeoParquet
+        run: |
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          import geopandas as gpd
+          import polars as pl
+
+          artifact = Path("data/normalized/geometria_comunal.parquet")
+          staging_csv = Path("data/staging/geometria_comunal.csv")
+          metadata_path = Path("data/staging/geometria_comunal.metadata.json")
+          raw_snapshots = list(Path("data/raw").glob("bcn_geometria_comunal_*.json"))
+          assert artifact.is_file(), f"Missing artifact: {artifact}"
+          assert staging_csv.is_file(), f"Missing staging CSV: {staging_csv}"
+          assert metadata_path.is_file(), f"Missing staging metadata: {metadata_path}"
+          assert raw_snapshots, "Missing raw BCN geometry snapshot"
+
+          frame = gpd.read_parquet(artifact)
+          assert len(frame) >= 340, f"Expected at least 340 geometries, got {len(frame)}"
+          assert frame.crs and frame.crs.to_epsg() == 4326, f"Unexpected CRS: {frame.crs}"
+          assert frame.geometry.notna().all(), "Geometry column contains null values"
+          assert not frame.geometry.is_empty.any(), "Geometry column contains empty geometries"
+          assert frame["codigo_comuna"].is_unique, "codigo_comuna must be unique"
+          assert frame["codigo_comuna"].map(
+              lambda value: isinstance(value, str) and len(value) == 5 and value.isdigit()
+          ).all(), "codigo_comuna must contain five-digit strings"
+          assert frame["codigo_region"].map(
+              lambda value: isinstance(value, str) and len(value) == 2 and value.isdigit()
+          ).all(), "codigo_region must contain two-digit strings"
+
+          metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+          assert metadata.get("dataset") == "geometria_comunal", "Unexpected staging dataset"
+          assert metadata.get("source_mode") == "live", "Candidate refresh must use live source data"
+          assert metadata.get("record_count") == len(frame), "Metadata record count does not match artifact"
+          staging_codes = set(
+              pl.read_csv(staging_csv, schema_overrides={"codigo_comuna": pl.String})[
+                  "codigo_comuna"
+              ]
+          )
+          assert set(frame["codigo_comuna"]).issubset(staging_codes), (
+              "GeoParquet codes do not match staging CSV"
+          )
+          print(f"Validated {len(frame)} geometries in EPSG:4326")
+          PY
+          uv run pytest tests/test_extractors.py tests/test_validation.py -v -k Geometria
+
+      - name: Generate GeoParquet checksum
+        run: |
+          (
+            cd data/normalized
+            sha256sum geometria_comunal.parquet > geometria_comunal.parquet.sha256
+            sha256sum -c geometria_comunal.parquet.sha256
+          )
+
+      - name: Commit validated candidate artifacts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          for path in \
+            data/normalized/geometria_comunal.parquet \
+            data/staging/geometria_comunal.csv \
+            data/staging/geometria_comunal.metadata.json \
+            data/normalized/geometria_comunal.parquet.sha256 \
+            data/raw/bcn_geometria_comunal_*.json
+          do
+            [ -e "$path" ] && git add -f "$path"
+          done
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(data): refresh candidate comunal geometry [skip ci]"
+            git push
+          fi
+
+      - name: Summary
+        run: |
+          records=$(uv run python -c "import geopandas as gpd; print(len(gpd.read_parquet('data/normalized/geometria_comunal.parquet')))" )
+          bytes=$(wc -c < data/normalized/geometria_comunal.parquet)
+          source_mode=$(uv run python -c "import json; print(json.load(open('data/staging/geometria_comunal.metadata.json', encoding='utf-8'))['source_mode'])")
+          {
+            echo "## Candidate comunal geometry"
+            echo ""
+            echo "- Records: ${records}"
+            echo "- Artifact size: ${bytes} bytes"
+            echo "- Source mode: ${source_mode}"
+            echo "- Boundary: candidate artifact only; excluded from the stable bundle and normal build."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **702 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **707 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **10 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/docs/datasets/geometria_comunal.md
+++ b/docs/datasets/geometria_comunal.md
@@ -49,6 +49,36 @@ FROM 'data/normalized/geometria_comunal.parquet'
 ORDER BY area DESC;
 ```
 
+## Publicación
+
+El artefacto se genera exclusivamente mediante el workflow manual
+`workflow_dispatch` **Refresh Candidate Comunal Geometry**. Tras una ejecución
+validada y el despliegue de Pages, está disponible para consumo directo en:
+
+- `https://tooltician.com/chile-hub/data/normalized/geometria_comunal.parquet`
+- `https://tooltician.com/chile-hub/data/normalized/geometria_comunal.parquet.sha256`
+
+Por ejemplo, se puede abrir directamente desde una herramienta GIS:
+
+```python
+import geopandas as gpd
+
+url = "https://tooltician.com/chile-hub/data/normalized/geometria_comunal.parquet"
+gdf = gpd.read_parquet(url)
+assert len(gdf) >= 340
+assert gdf.crs.to_epsg() == 4326
+```
+
+Verifica la descarga antes de usarla con `sha256sum -c` desde el directorio que
+contiene ambos archivos:
+
+```bash
+sha256sum -c geometria_comunal.parquet.sha256
+```
+
+Sigue siendo datos `candidate`: queda deliberadamente fuera de `ChileHub()`, del
+bundle estable y del build normal. El workflow no fija una cadencia de refresco.
+
 ## Limitaciones
 
 - **No usar para precisión geodésica ni catastral.** La fuente BCN es cartografía de referencia a escala nacional, no un catastro de límites legales.

--- a/plans/050-resolve-comunas-name-to-cut.md
+++ b/plans/050-resolve-comunas-name-to-cut.md
@@ -13,7 +13,7 @@
 > explícita — ver STOP conditions.
 >
 > **Drift check (córrelo primero)**:
-> `git diff --stat 7ebf94b..HEAD -- src/chile_hub/core.py src/extractors/subdere_extractor.py src/extractors/autoridades_locales_extractor.py`
+> `git diff --stat 63cc106..HEAD -- src/chile_hub/core.py src/extractors/subdere_extractor.py src/extractors/autoridades_locales_extractor.py`
 > Si alguno de esos archivos cambió desde que se escribió este plan, compara los
 > excerptos de "Estado actual" contra el código vivo antes de continuar; ante una
 > discrepancia, trátalo como STOP condition.
@@ -25,7 +25,7 @@
 - **Risk**: LOW-MED (decisión de alcance determinista vs. fuzzy es el único riesgo real)
 - **Depends on**: none
 - **Category**: direction
-- **Planned at**: commit `7ebf94b`, 2026-07-14
+- **Planned at**: commit `63cc106`, 2026-07-26 (revalidated)
 
 ## Why this matters
 
@@ -354,7 +354,7 @@ Todas deben cumplirse:
 Detente y reporta (no improvises) si:
 
 - El código en `subdere_extractor.py:558-570` o `autoridades_locales_extractor.py:437`
-  no coincide con los excerptos de "Estado actual" (el repo derivó desde `7ebf94b`).
+  no coincide con los excerptos de "Estado actual" (el repo derivó desde `63cc106`).
 - El dataset `comunas` no tiene la columna `nombre_comuna_clean` al cargarlo (indica
   que el build cambió el schema; no inventes la columna).
 - El chequeo de colisiones del Step 4 revela `nombre_comuna_clean` duplicados **y** no

--- a/plans/051-static-http-access-and-dcat-catalog.md
+++ b/plans/051-static-http-access-and-dcat-catalog.md
@@ -14,7 +14,7 @@
 > **para** (STOP condition).
 >
 > **Drift check (córrelo primero)**:
-> `git diff --stat 7ebf94b..HEAD -- src/chile_hub/core.py src/builders/data_package.py src/build_dev_db.py .github/workflows/pages-deploy.yml README.md`
+> `git diff --stat 63cc106..HEAD -- src/chile_hub/core.py src/builders/data_package.py src/build_dev_db.py .github/workflows/pages-deploy.yml README.md`
 > Si algo cambió, compara los excerptos de "Estado actual" contra el código vivo
 > antes de continuar; ante discrepancia, trátalo como STOP condition.
 
@@ -25,7 +25,7 @@
 - **Risk**: LOW
 - **Depends on**: none
 - **Category**: direction
-- **Planned at**: commit `7ebf94b`, 2026-07-14
+- **Planned at**: commit `63cc106`, 2026-07-26 (revalidated)
 
 ## Why this matters
 
@@ -261,7 +261,7 @@ por `sync_docs.py`).
 Detente y reporta si:
 
 - El código de `from_datapackage` o `data_package.py` no coincide con "Estado actual"
-  (drift desde `7ebf94b`).
+  (drift desde `63cc106`).
 - Te descubres diseñando un servidor, endpoint dinámico, auth o billing — eso viola la
   línea roja del product-spec; el spike es **sólo archivos estáticos**.
 - No puedes confirmar el base URL real en `README.md` — no inventes un dominio;

--- a/plans/053-comuna-geometry-and-reverse-geocoding.md
+++ b/plans/053-comuna-geometry-and-reverse-geocoding.md
@@ -1,5 +1,13 @@
 # Plan 053: Geometría comunal (GeoParquet) + reverse geocoding `resolve_by_coords()`
 
+> **Execution state (2026-07-26):** Steps 0–3 are complete. Their resulting
+> extractor, validator, standalone builder, contract, documentation, and ADRs are
+> now the current state of the repository. The remaining work was deliberately
+> split into Plan 064 (CI-owned artifact publication) and Plan 065 (runtime
+> `resolve_by_coords()`), because publishing a candidate artifact and exposing a
+> consumer API have different failure modes and verification gates. Do not rerun
+> Steps 0–3 from this historical parent plan.
+
 > **Executor instructions**: Este es un **feasibility-spike con entregable de datos**.
 > Sigue los pasos en orden y respeta las compuertas (gates). El Step 1 es una
 > **compuerta de licencia que puede matar el plan** — si no se confirma, detente y

--- a/plans/054-temporal-anomaly-validation-numeric-series.md
+++ b/plans/054-temporal-anomaly-validation-numeric-series.md
@@ -12,7 +12,7 @@
 > validación que corta el build. Ver Step 3.
 >
 > **Drift check (córrelo primero)**:
-> `git diff --stat 7ebf94b..HEAD -- src/validation.py src/builders/reports.py scripts/verify_pipeline.py`
+> `git diff --stat 63cc106..HEAD -- src/validation.py src/builders/reports.py scripts/verify_pipeline.py`
 > Ante discrepancia con los excerptos de "Estado actual", trátalo como STOP.
 
 ## Status
@@ -24,7 +24,7 @@
   eso el gate correcto es publicación, no build)
 - **Depends on**: none
 - **Category**: direction (confiabilidad como diferenciador de producto)
-- **Planned at**: commit `7ebf94b`, 2026-07-14
+- **Planned at**: commit `63cc106`, 2026-07-26 (revalidated)
 
 ## Why this matters
 
@@ -224,7 +224,7 @@ Detente y reporta si:
   `make build` (el gate rompería publicaciones sanas) — recalibra el umbral **una vez** y,
   si persiste, reporta antes de relajar la señal a inútil.
 - `validate_indicadores`, `build_drift_report` o `verify_pipeline.py` no coinciden con
-  "Estado actual" (drift desde `7ebf94b`).
+  "Estado actual" (drift desde `63cc106`).
 - Cualquier verificación falla dos veces tras un intento razonable.
 
 ## Maintenance notes

--- a/plans/058-catalogo-campo-extractor-y-tabla-readme.md
+++ b/plans/058-catalogo-campo-extractor-y-tabla-readme.md
@@ -7,7 +7,7 @@
 > in `plans/README.md` — unless a reviewer dispatched you and told you they
 > maintain the index.
 >
-> **Drift check (run first)**: `git diff --stat 6bf6b08..HEAD -- data/dataset_catalog_config.json scripts/check_companion_paths.py src/builders/doc_sync.py README.md AGENTS.md tests/test_pipeline_logic.py`
+> **Drift check (run first)**: `git diff --stat 63cc106..HEAD -- data/dataset_catalog_config.json scripts/check_companion_paths.py src/builders/doc_sync.py README.md AGENTS.md tests/test_pipeline_logic.py`
 > If any in-scope file changed since this plan was written, compare the
 > "Current state" excerpts against the live code before proceeding; on a
 > mismatch, treat it as a STOP condition.
@@ -19,12 +19,12 @@
 - **Risk**: LOW
 - **Depends on**: none (disjoint from plans 050–057)
 - **Category**: direction / dx
-- **Planned at**: commit `6bf6b08`, 2026-07-18
+- **Planned at**: commit `63cc106`, 2026-07-26 (revalidated)
 
 ## Why this matters
 
 `AGENTS.md` §12 (política anti-drift) lista explícitamente como "Seguimiento
-recomendado, no implementado todavía": agregar un campo `"extractor"` a las 21
+recomendado, no implementado todavía": agregar un campo `"extractor"` a las 22
 entradas de `data/dataset_catalog_config.json`, lo que permite (a) generar
 automáticamente la tabla de extractores de `README.md` — hoy manual y ya quedó
 stale una vez — y (b) extender `scripts/check_companion_paths.py registry` para
@@ -35,7 +35,7 @@ a dato validado en CI en cada push/PR.
 
 ## Current state
 
-- `data/dataset_catalog_config.json` — dict de 21 claves. Cada entrada tiene
+- `data/dataset_catalog_config.json` — dict de 22 claves. Cada entrada tiene
   `description`, `join_keys`, `confidence_tier`, `expected_record_count`,
   `reuse_policy`, `freshness_policy`, `usage_examples`, `outputs` (ausente en
   carril `candidate`), `documentation`. **No existe el campo `extractor`.**
@@ -44,7 +44,7 @@ a dato validado en CI en cada push/PR.
   distritos_electorales, establecimientos_educacionales, finanzas_municipales,
   resultados_educacionales, indicadores_urbanos_siedu,
   perfil_territorial_comunal, empresas, pobreza_comunal,
-  consumo_electrico_comunal, delincuencia_comunal, partidos_politicos,
+  consumo_electrico_comunal, geometria_comunal, delincuencia_comunal, partidos_politicos,
   autoridades_electas, autoridades_locales`.
 - `scripts/check_companion_paths.py` — `check_registry()` (L56–67) hoy valida
   contrato + doc por dataset:
@@ -103,6 +103,7 @@ a dato validado en CI en cada push/PR.
 | empresas | `"src/extractors/res_extractor.py"` |
 | pobreza_comunal | `"src/extractors/pobreza_extractor.py"` |
 | consumo_electrico_comunal | `"src/extractors/consumo_electrico_extractor.py"` |
+| geometria_comunal | `"src/extractors/geometria_comunal_extractor.py"` |
 | delincuencia_comunal | `"src/extractors/cead_delincuencia_live_extractor.py"` |
 | partidos_politicos | `"src/extractors/partidos_politicos_extractor.py"` |
 | autoridades_electas | `"src/extractors/autoridades_electas_extractor.py"` |
@@ -116,7 +117,8 @@ establecimientos_educacionales, resultados_educacionales · Economía:
 indicadores, finanzas_municipales, empresas, consumo_electrico_comunal ·
 Indicadores urbanos: indicadores_urbanos_siedu · Política: partidos_politicos,
 autoridades_electas, autoridades_locales · Seguridad (carril `candidate`):
-delincuencia_comunal · `perfil_territorial_comunal`: derivado (fila aparte).
+delincuencia_comunal · Territorio (carril `candidate`): geometria_comunal ·
+`perfil_territorial_comunal`: derivado (fila aparte).
 
 ## Commands you will need
 
@@ -151,14 +153,14 @@ delincuencia_comunal · `perfil_territorial_comunal`: derivado (fila aparte).
 
 - Branch: `advisor/058-catalog-extractor-field`
 - Conventional commits en español, estilo del repo: p. ej.
-  `feat(catalog): agrega campo extractor a las 21 entradas del catálogo`,
+  `feat(catalog): agrega campo extractor a las 22 entradas del catálogo`,
   `feat(ci): valida extractores en check_companion_paths registry`,
   `feat(docs): auto-genera tabla de extractores de README`.
 - No pushear ni abrir PR salvo instrucción del operador.
 
 ## Steps
 
-### Step 1: Agregar el campo `extractor` a las 21 entradas del catálogo
+### Step 1: Agregar el campo `extractor` a las 22 entradas del catálogo
 
 En `data/dataset_catalog_config.json`, agrega a cada entrada el campo
 `"extractor"` con el valor exacto de la tabla de mapeo de "Current state"
@@ -167,7 +169,7 @@ existentes (el archivo está ordenado por clave dentro de cada entrada:
 `confidence_tier`, `description`, `documentation`, `expected_record_count`,
 `extractor`, `freshness_policy`, …).
 
-**Verify**: `python3 -c "import json; d=json.load(open('data/dataset_catalog_config.json')); assert len(d)==21; missing=[k for k,v in d.items() if 'extractor' not in v]; assert not missing, missing; print('21/21 entradas con campo extractor')"` → `21/21 entradas con campo extractor`
+**Verify**: `python3 -c "import json; d=json.load(open('data/dataset_catalog_config.json')); assert len(d)==22; missing=[k for k,v in d.items() if 'extractor' not in v]; assert not missing, missing; print('22/22 entradas con campo extractor')"` → `22/22 entradas con campo extractor`
 
 ### Step 2: Extender `check_registry()` con validación de extractores
 
@@ -213,7 +215,7 @@ En `scripts/check_companion_paths.py`:
 
 En `src/builders/doc_sync.py`:
 
-1. Agrega `_README_DATASET_DOMAINS` dict de las 21 claves → dominio (strings
+1. Agrega `_README_DATASET_DOMAINS` dict de las 22 claves → dominio (strings
    del agrupamiento de "Current state"; `perfil_territorial_comunal` mapea a
    `None` = derivado), siguiendo el patrón de `_AGENTS_TEST_DESCRIPTIONS`.
 2. Agrega `sync_readme_extractor_table(check_only=False)`: agrupa datasets por
@@ -277,7 +279,7 @@ temporales) y sobre el mecanismo de import de scripts que use
 (importlib desde path, si ese es el patrón ahí; si no, subprocess). Casos:
 
 1. `check_extractors` con catálogo real → lista de errores vacía (regresión:
-   las 21 entradas referencian archivos existentes y no hay huérfanos).
+   las 22 entradas referencian archivos existentes y no hay huérfanos).
 2. Fixture temporal: entrada con `"extractor": "src/extractors/no_existe.py"`
    → error "extractor no existe".
 3. Fixture temporal: archivo `src/extractors/huerfano_extractor.py` creado en
@@ -310,8 +312,8 @@ pass, incluyendo los ≥6 nuevos tests.
 
 Stop and report back (do not improvise) if:
 
-- El catálogo tiene ≠21 entradas o alguna clave difiere de la tabla de mapeo
-  (drift desde `6bf6b08`).
+- El catálogo tiene ≠22 entradas o alguna clave difiere de la tabla de mapeo
+  (drift desde `63cc106`).
 - La tabla manual de README ya no está en L682–694 o su contenido difiere del
   excerpt de "Current state" (alguien la editó; reconciliar antes de generar).
 - El patrón `replace_delimited_block` no logra reproducir la tabla actual con

--- a/plans/064-publish-geometry-artifact-from-ci.md
+++ b/plans/064-publish-geometry-artifact-from-ci.md
@@ -1,0 +1,191 @@
+# Plan 064: Publish the candidate GeoParquet through a CI-owned workflow
+
+> **Executor instructions**: Follow each step in order and run every verification
+> gate. Do not weaken a repository guard or substitute another storage mechanism.
+> On any STOP condition, report it rather than improvising. When all done criteria
+> pass, update this plan's row in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 63cc106..HEAD -- scripts/build_geometria_comunal.py src/extractors/geometria_comunal_extractor.py src/builders/geo.py .github/workflows/monthly-scrape.yml .github/workflows/pages-deploy.yml .pre-commit-config.yaml tests/test_ci_config.py docs/datasets/geometria_comunal.md`
+> If in-scope code no longer matches the Current state, STOP.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: direction / distribution
+- **Planned at**: commit `63cc106`, 2026-07-26
+
+## Why this matters
+
+The geometry extractor, validator, and GeoParquet writer are complete, but no
+artifact is available to users: the roughly 5 MB output is absent from the repo
+because the local 500 KB large-file guard blocks a manual commit. The existing
+monthly candidate workflows establish the correct mechanism—CI validates and
+commits ignored data with explicit repository write permission. This plan applies
+that mechanism without weakening the guard for normal source commits.
+
+The result is a Pages-served, directly consumable GIS file plus a SHA-256 companion
+file. It remains candidate data: it must not join the daily build, stable catalog,
+publishable ZIP, or PyPI runtime bundle.
+
+## Current state
+
+- `scripts/build_geometria_comunal.py:1-13` is intentionally standalone: extract
+  → fail-loud validation → GeoParquet write, never `make build`.
+- `src/extractors/geometria_comunal_extractor.py:13-17` fetches per region and
+  falls back to per-comuna requests; it writes raw snapshots and staging data.
+- `src/builders/geo.py:18-23` uses `0.001` degrees simplification; ADR-012
+  records a valid ~4.98 MB GeoParquet.
+- `.pre-commit-config.yaml:10-11` has `check-added-large-files --maxkb=500`.
+- `.github/workflows/monthly-scrape.yml:14-16,71-90` is the workflow exemplar:
+  `contents: write`, `git add -f`, no-change handling, and a `[skip ci]` commit.
+- `.github/workflows/pages-deploy.yml:57-59` deploys the repository root, so a
+  committed normalized artifact is served by the existing static site.
+- The stable bundle already uses `.sha256` companion files; geometry needs the
+  same small, independently fetchable integrity artifact without entering that bundle.
+- ADR-012 requires geometry to remain outside `build_dev_db.py`, `make extract`,
+  and the generated stable catalog.
+
+## Commands you will need
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| CI-equivalent dependencies | `uv sync --extra pipeline --extra dev --locked` | exit 0 |
+| Build geometry | `uv run python scripts/build_geometria_comunal.py` | exit 0; ≥340 records |
+| Inspect artifact | `uv run python -c "import geopandas as gpd; d=gpd.read_parquet('data/normalized/geometria_comunal.parquet'); assert len(d)>=340; assert d.crs.to_epsg()==4326; print(len(d))"` | prints ≥340 |
+| Geometry tests | `uv run pytest tests/test_extractors.py tests/test_validation.py -v -k Geometria` | selected tests pass |
+| CI tests | `uv run pytest tests/test_ci_config.py -v` | all pass |
+| Quality | `make lint && make format-check && make doctor` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `.github/workflows/geometria-comunal.yml` (create)
+- `tests/test_ci_config.py`
+- `docs/datasets/geometria_comunal.md`
+- `plans/README.md` status
+
+**Out of scope**:
+
+- `.pre-commit-config.yaml`, `Makefile`, `src/build_dev_db.py`, the dataset
+  config, `Dataset` enum, package/release workflows, and public bundle scripts.
+- `src/chile_hub/core.py` and any coordinate resolver (Plan 065).
+- Scheduled refreshes: begin with manual dispatch only.
+
+## Git workflow
+
+- Branch: `advisor/064-publish-geometry-artifact`
+- Commit: `feat(ci): publica GeoParquet comunal bajo demanda`
+- Do not push, dispatch, or alter Pages settings without explicit operator approval.
+
+## Steps
+
+### Step 1: Create an isolated, manually dispatched workflow
+
+Create `.github/workflows/geometria-comunal.yml`, structurally modeled on the
+SINIM job in `monthly-scrape.yml`.
+
+1. Trigger only on `workflow_dispatch`; no `schedule`.
+2. Use top-level `permissions: contents: write`, a dedicated concurrency group,
+   Ubuntu, Python 3.13, uv cache, and a 20-minute timeout.
+3. Run `uv lock --locked`, then `uv sync --extra pipeline --extra dev --locked`.
+4. Run exactly `uv run python scripts/build_geometria_comunal.py`; do not use
+   `--skip-fetch`, `make build`, or `make extract`.
+5. Before any commit, read the result with geopandas and assert: file exists,
+   ≥340 records, CRS EPSG:4326, no null geometry, and five-character CUT values.
+   Also run focused geometry extractor/validation tests.
+
+**Verify**: `rg -n "workflow_dispatch|contents: write|build_geometria_comunal.py|make build|schedule" .github/workflows/geometria-comunal.yml` → the first three appear; the latter two do not.
+
+### Step 2: Stage only successfully validated candidate artifacts
+
+Add a commit step after validation, following `monthly-scrape.yml:71-90`.
+
+Before staging, generate the checksum:
+
+```bash
+sha256sum data/normalized/geometria_comunal.parquet \
+  > data/normalized/geometria_comunal.parquet.sha256
+```
+
+The companion must contain the conventional digest plus the artifact path. It is
+the integrity contract consumed by Plan 065.
+
+- Configure `github-actions[bot]` identity.
+- Use `git add -f` only for:
+  `data/normalized/geometria_comunal.parquet`,
+  `data/staging/geometria_comunal.csv`,
+  `data/staging/geometria_comunal.metadata.json`,
+  `data/normalized/geometria_comunal.parquet.sha256`, and
+  `data/raw/bcn_geometria_comunal_*.json`.
+- If no staged diff exists, print `No changes to commit` and exit 0.
+- Otherwise commit `chore(data): refresh candidate comunal geometry [skip ci]`
+  and push.
+- Add a summary with record count, byte size, metadata source mode, and the
+  candidate/outside-bundle boundary. Never print raw payload data or secrets.
+
+**Verify**: `sha256sum -c data/normalized/geometria_comunal.parquet.sha256` →
+`data/normalized/geometria_comunal.parquet: OK`; and
+`rg -n "git add -f|geometria_comunal.parquet.sha256|\[skip ci\]" .github/workflows/geometria-comunal.yml` → all patterns appear.
+
+### Step 3: Add CI configuration regression tests
+
+Add `GeometriaCandidateWorkflowGuardrailTests` to `tests/test_ci_config.py`, using
+the repository's existing text-based workflow-test style. Assert that the workflow:
+
+- is manual only and unscheduled;
+- uses locked pipeline/dev dependencies;
+- calls the standalone builder and validates before its commit step;
+- stages only the five allowed geometry path families, including the checksum;
+- has `contents: write` and `[skip ci]`; and
+- does not call the daily build or publishable bundle scripts.
+
+**Verify**: `uv run pytest tests/test_ci_config.py -v` → all pass.
+
+### Step 4: Document the distribution boundary
+
+Add a “Publication” section to `docs/datasets/geometria_comunal.md`. State that
+the manually dispatched workflow generates the file, Pages serves it at
+`https://tooltician.com/chile-hub/data/normalized/geometria_comunal.parquet` and
+its adjacent `.sha256` file after deployment, and GIS users read it directly.
+State explicitly that it is candidate data and excluded from `ChileHub()`'s stable
+bundle and normal build. Include CRS/record-count and `sha256sum -c` verification;
+do not promise a refresh cadence.
+
+**Verify**: `make doctor` → exit 0; `rg -n "candidate|workflow_dispatch|geometria_comunal.parquet" docs/datasets/geometria_comunal.md` → all terms appear.
+
+## Test plan
+
+- New CI guardrail tests in `tests/test_ci_config.py`.
+- Local integration: build, then inspect the GeoParquet's records, CRS, and geometry.
+- Regression: focused extractor/validator tests plus `make doctor` and quality checks.
+- Manual post-dispatch acceptance: inspect the bot commit and workflow summary,
+  wait for Pages, and execute `gpd.read_parquet(<Pages URL>)` with the same
+  record-count/CRS assertions. This changes remote state and requires operator approval.
+
+## Done criteria
+
+- [ ] Workflow is manual-only and passes its guardrail tests.
+- [ ] It validates before committing, writes a valid `.sha256` companion, and stages only the allowed artifacts.
+- [ ] The 500 KB pre-commit guard is unchanged.
+- [ ] Geometry stays absent from the stable catalog, daily build, and ZIP.
+- [ ] Focused tests, `make doctor`, lint, and format checks exit 0.
+- [ ] Documentation accurately describes direct Pages access and candidate status.
+- [ ] Plan 064 is marked DONE only after successful workflow dispatch and Pages readback.
+
+## STOP conditions
+
+- Fewer than 340 valid geometries, non-EPSG:4326 CRS, or invalid CUT widths.
+- The only solution changes the large-file limit or bypasses a hook.
+- The workflow needs the daily build, stable catalog, or publishable bundle.
+- Branch protections prevent the Actions bot from pushing; report the required
+  maintainer configuration rather than inventing credentials or deploy keys.
+
+## Maintenance notes
+
+Keep the workflow manual until demand justifies a cadence. Any future schedule
+must keep the same validation and candidate-only boundaries. Plan 065 can consume
+the artifact and its checksum only after this plan's Pages readback succeeds.

--- a/plans/065-add-coordinate-resolver.md
+++ b/plans/065-add-coordinate-resolver.md
@@ -1,0 +1,215 @@
+# Plan 065: Expose verified coordinate-to-comuna resolution
+
+> **Executor instructions**: Follow every step and verification gate. Do not make
+> candidate geometry part of the stable bundle and do not add geo libraries to the
+> base installation. If an artifact URL cannot be integrity-verified, STOP and
+> report it. Update this plan's row in `plans/README.md` only when all done
+> criteria are true.
+>
+> **Drift check (run first)**: `git diff --stat 63cc106..HEAD -- src/chile_hub/core.py src/chile_hub/data_manager.py src/chile_hub/exceptions.py pyproject.toml tests/test_core.py tests/test_chile_hub.py docs/adr/ADR-012-geometria-comunal-y-reverse-geocoding.md docs/datasets/geometria_comunal.md`
+> If source behavior differs from Current state, STOP rather than silently changing
+> the API contract.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: Plan 064
+- **Category**: direction / API
+- **Planned at**: commit `63cc106`, 2026-07-26
+
+## Why this matters
+
+Users with GPS points, geocoded addresses, sensors, or field observations need an
+official comuna CUT before joining hub data. The repository now has official,
+license-cleared geometry but no public point-in-polygon API. This is the spatial
+counterpart to Plan 050's name-to-CUT resolver.
+
+The API must use a separately cached, integrity-verified candidate artifact. The
+normal data manager downloads only the stable publishable bundle; pulling geometry
+into it would violate the publication-track architecture and impose GIS libraries
+on every consumer.
+
+## Current state
+
+- `src/chile_hub/core.py` exposes public Polars-returning methods such as
+  `cross_view`, `search_datasets`, and `sql`, but no coordinate resolver.
+- `src/chile_hub/data_manager.py` downloads, SHA-256-verifies, and extracts only
+  the stable release bundle. It must not be repurposed to replace that bundle with
+  a candidate artifact.
+- `pyproject.toml:45-63` has `pipeline`, `query`, and `validation` extras.
+  `shapely`/`geopandas` are build-time dependencies in `pipeline`, not a public
+  consumer `geo` extra.
+- `src/builders/geo.py` writes GeoParquet 1.0 (WKB, EPSG:4326). ADR-012 keeps it
+  out of the daily generated catalog and requires direct-file access.
+- Plan 064 provides the Pages artifact and its adjacent `.sha256` companion.
+  That immutable pair is the required integrity contract for this API.
+
+## Commands you will need
+
+| Purpose | Command | Expected result |
+|---|---|---|
+| Optional geo environment | `uv sync --extra geo --extra dev --locked` | exit 0 |
+| Build stable fixture data | `make build` | exit 0 |
+| Core tests | `uv run pytest tests/test_core.py -v` | all pass |
+| Cache/API tests | `uv run pytest tests/test_chile_hub.py -v -k "DataManager or resolve_by_coords"` | selected tests pass |
+| Full regression | `make test` | exit 0 |
+| Quality | `make lint && make format-check && make docs-coverage` | exit 0 |
+
+## Scope
+
+**In scope**:
+
+- `pyproject.toml`, `uv.lock` — consumer-only `geo` extra.
+- `src/chile_hub/geo.py` (create) — lazy download/cache, checksum verification,
+  GeoParquet validation, and pure spatial helpers.
+- `src/chile_hub/core.py` — `ChileHub.resolve_by_coords()`.
+- `src/chile_hub/exceptions.py` only if `ChileHubDataError` cannot express the
+  final failure clearly.
+- `tests/test_core.py`, `tests/test_chile_hub.py`, ADR-012, geometry dataset docs,
+  and `plans/README.md`.
+
+**Out of scope**:
+
+- Base `dependencies`; `data/dataset_catalog_config.json`; `Dataset` enum;
+  `make extract`; `build_dev_db.py`; CLI; stable bundle/release workflows.
+- Artifact publication and checksum creation (Plan 064),
+  fuzzy matching, addresses, roads, or a map UI.
+
+## Git workflow
+
+- Branch: `advisor/065-coordinate-resolver`
+- Commit: `feat(geo): agrega resolve_by_coords para comunas`
+- Do not push or publish a package without explicit operator instruction.
+
+## Steps
+
+### Step 1: Freeze the distribution and cache contract
+
+Read the completed Plan 064 workflow and documentation before writing code.
+Record these decisions in ADR-012:
+
+- the HTTPS GeoParquet URL;
+- the adjacent `.sha256` URL and its digest/path parsing rules;
+- a versioned cache directory under `platformdirs.user_cache_dir("chile-hub")`;
+- default behavior: reuse a verified cache, refresh only with
+  `refresh_geometry=True`; and
+- offline/missing/checksum failure behavior.
+
+The public method must not accept an unchecked arbitrary URL. It may accept a
+keyword-only `geometry_path: Path | None` for offline and test use; the local file
+must still pass structural GeoParquet validation.
+
+**Verify**: `rg -n "SHA-256|cache|refresh_geometry|geometry_path" docs/adr/ADR-012-geometria-comunal-y-reverse-geocoding.md` → all concepts appear.
+
+### Step 2: Add a lazy, consumer-only geo extra
+
+Add `geo` under `[project.optional-dependencies]`, separate from `pipeline`, with
+the smallest compatible set needed for GeoParquet reading and point-in-polygon
+work (expected: geopandas, shapely, and pyarrow if required). Keep existing
+pipeline dependencies intact and regenerate `uv.lock` using the normal uv flow.
+
+Import geo libraries only inside the new geo module or its helpers. Without them,
+`resolve_by_coords()` must raise `ImportError` containing exactly
+`pip install chile-hub[geo]`, following `ChileHub.sql()`'s lazy-extra pattern.
+
+**Verify**: `uv sync --extra geo --extra dev --locked` → exit 0; an import-mocked
+test proves `ChileHub()` construction does not import geopandas and method use
+without the extra gives the specified error.
+
+### Step 3: Implement verified artifact acquisition and validation
+
+Create `src/chile_hub/geo.py`; keep network/spatial details out of `core.py`.
+Implement helpers that:
+
+1. fetch and parse the Plan 064 `.sha256` companion before accepting a download;
+2. download atomically to a temporary sibling file, calculate SHA-256, and
+   replace the cache only when it equals the descriptor digest;
+3. preserve any previous verified cache on failed download or bad checksum;
+4. validate GeoParquet: geometry column, EPSG:4326, string-like five-character
+   `codigo_comuna`, no duplicate CUT, at least 340 non-empty geometries; and
+5. expose a pure function taking an already loaded GeoDataFrame plus points for
+   network-free tests.
+
+Use `ChileHubDataError` unless its existing semantics make the root cause unclear.
+Do not reuse the stable bundle extractor because it replaces the normalized cache.
+
+**Verify**: fixture tests prove a checksum mismatch leaves an existing cache
+untouched, malformed GeoParquet raises a useful data error, and a valid local
+fixture triggers no HTTP request.
+
+### Step 4: Add the public coordinate resolver with a fixed contract
+
+Add this method near the other data-access methods:
+
+```python
+def resolve_by_coords(
+    self,
+    points: list[tuple[float, float]],
+    *,
+    refresh_geometry: bool = False,
+    geometry_path: Path | None = None,
+) -> pl.DataFrame:
+```
+
+Each tuple is `(latitud, longitud)`. Preserve input order and duplicates. Return
+one row per input with exactly `input_lat`, `input_lon`, `codigo_comuna`,
+`nombre_comuna`, and `matched`. Valid points outside Chile yield null comuna
+fields and `matched=False`; latitude outside `[-90, 90]` or longitude outside
+`[-180, 180]` raises `ValueError` naming the invalid input.
+
+Use `geometry.covers(point)`, not `contains`, so boundary points match. If several
+geometries cover a point, return the lexicographically smallest `codigo_comuna`
+and emit a module-log warning; document this deterministic tie-break.
+
+**Verify**: a Santiago-center point matches a five-character CUT; a sea point is
+unmatched; a synthetic boundary fixture proves `covers`; duplicated input yields
+duplicated output rows in the same order.
+
+### Step 5: Document and test supported failure modes
+
+Update geometry docs with `pip install "chile-hub[geo]"`, tuple order, output
+schema, cache behavior, candidate/stable-bundle boundary, out-of-Chile behavior,
+and the generalized-boundary precision disclaimer. Add the final cache, integrity,
+and boundary decisions to ADR-012.
+
+Model lazy-import tests on `ChileHubSQLTests`; model cache/SHA tests on current
+data-manager unit tests. Use a tiny synthetic GeoParquet fixture, never the 5 MB
+production artifact.
+
+**Verify**: `make test && make lint && make format-check && make docs-coverage` → all exit 0.
+
+## Test plan
+
+- Known match, unmatched point, duplicate/order preservation, invalid coordinates,
+  boundary match, and deterministic overlap handling.
+- Lazy extra behavior and base-instantiation no-import behavior.
+- Companion/download success, checksum mismatch cache preservation, offline use
+  with a verified cache, offline failure without one.
+- Structural failures: missing geometry/CRS, bad CUT width, duplicate CUT, too few rows.
+- Complete suite, lint, formatting, and docs coverage.
+
+## Done criteria
+
+- [ ] Plan 064 is DONE; this plan uses its documented artifact/checksum contract.
+- [ ] `geo` is optional and base dependencies/install behavior are unchanged.
+- [ ] Remote artifacts are verified before replacing cache; bad data preserves cache.
+- [ ] API returns the specified Polars schema and documented boundary behavior.
+- [ ] Candidate geometry remains outside the stable catalog and publishable bundle.
+- [ ] All tests and quality commands above exit 0.
+- [ ] ADR and dataset docs specify cache, integrity, input, output, and precision behavior.
+
+## STOP conditions
+
+- No stable Pages artifact URL plus `.sha256` companion is available from Plan 064.
+- Plan 064 has not successfully published and read back the artifact.
+- Dependencies require a base-install change or violate the documented Python range.
+- Structural validation fails on a known valid artifact or border policy is not deterministic.
+- The design requires adding geometry to the stable bundle or generated catalog.
+
+## Maintenance notes
+
+The cache URL and checksum companion are a deliberate coupling to Plan 064; change
+them together and preserve a migration path. Review coordinate order, lazy imports,
+checksum-before-replace behavior, and the explicit non-cadastral precision limit.

--- a/plans/066-taxonomia-drift-esperado-vs-real.md
+++ b/plans/066-taxonomia-drift-esperado-vs-real.md
@@ -1,0 +1,410 @@
+# Plan 066: Separar drift esperado de drift real en el dashboard de salud
+
+> **Executor instructions**: Sigue cada paso y su gate de verificación. Este plan
+> **no repara datos**: corrige la clasificación de estados. Si en algún paso la
+> única forma de bajar un contador es tocando datos o relajando un gate, es una
+> STOP condition — repórtalo, no improvises. No corras `make refresh` sin red
+> (todos los extractores caerían a fallback y fabricarías drift falso). Actualiza
+> la fila de este plan en `plans/README.md` sólo cuando todos los done criteria
+> sean verdaderos.
+>
+> **Drift check (córrelo primero)**: `git diff --stat b79461f..HEAD -- src/builders/metadata.py src/builders/reports.py src/chile_hub/pipeline_status_utils.py src/validation.py scripts/verify_pipeline.py contracts/datasets/ app.js`
+> Si el comportamiento real difiere de "Estado actual", DETENTE en vez de cambiar
+> silenciosamente el contrato de estados.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED (toca el vocabulario del dashboard público de salud y contadores
+  que la landing renderiza; ningún cambio de dato)
+- **Depends on**: ninguno
+- **Category**: correctness / observabilidad
+- **Planned at**: commit `b79461f`, 2026-07-26
+
+## Por qué importa
+
+`hub_health.json` (snapshot 2026-07-21) reporta `drifted_count: 8` y
+`warn_count: 7` sobre 19 datasets. La auditoría dataset por dataset muestra que
+**4 de los 8 "drifted" son un bug de clasificación, no un problema de datos**:
+
+| Dataset | Realidad | Por qué se marca drifted hoy |
+|---|---|---|
+| `perfil_territorial_comunal` | derivado de capas validadas, 346/346, **0 warnings** | su `source_mode` se calcula `"live" if all(upstream == "live") else "fallback"`; `finanzas_municipales` es `monthly` → cae a `fallback` |
+| `finanzas_municipales` | 345/346, 0 warnings; su contrato **ya declara** `coverage_policy: "partial_expected"` | `build_coverage` nunca lee `coverage_policy` |
+| `indicadores_urbanos_siedu` | cobertura urbana intencional (0.3382); contrato **ya declara** `partial_expected` | idem, más un warning informativo |
+| `pobreza_comunal` | SAE 345/346, "parcial por diseño" según su propio warning | cualquier warning ⇒ `degradation: warning` ⇒ drifted |
+| `partidos_politicos` | 36/36, `estado_legal` poblado en 15/36 (dato de SERVEL, no un fallo) | idem |
+
+Los otros 3 son legítimos: `empresas` (1 RUT inválido), `indicadores` (reusó el
+artefacto publicado para `ipc`) y `consumo_electrico_comunal` (fuente
+decomisionada por CNE, AGENTS.md §6).
+
+El costo de no arreglarlo es que el dashboard público entrena a sus lectores a
+ignorar `drifted_count`: si 4 de 8 alarmas son ruido estructural, la señal de las
+4 reales se pierde. `plans/README.md` dejó explícitamente fuera de alcance el
+"vocabulario del dashboard de salud" en la auditoría 2026-07-13; este plan cierra
+ese pendiente.
+
+## Estado actual
+
+- **El predicado único de drift** — `src/builders/metadata.py:228-234`:
+
+  ```python
+  drift_status = "healthy"
+  if (
+      source_mode == "fallback"
+      or coverage_status in {"partial", "unknown"}
+      or degradation_status in {"warning", "degraded"}
+  ):
+      drift_status = "drifted"
+  ```
+
+  No existe un concepto de "parcial esperado" ni de "warning informativo".
+
+- **`build_coverage`** (`metadata.py:161-218`) sólo honra
+  `dataset_metadata["coverage"]["status"] == "partial_expected"` — que **únicamente
+  `src/extractors/siedu_extractor.py:320` produce** — y aun así lo colapsa a
+  `"partial"` a secas, destruyendo la señal antes de que `build_drift` la vea.
+  **No lee `coverage_policy` del contrato**, pese a que `load_schema_contract` ya
+  está importado y se usa en el mismo `enrich_dataset_metadata` (`metadata.py:263`).
+
+- **`coverage_policy` ya existe en los 22 contratos** de `contracts/datasets/`:
+  `full` (8), `not_applicable` (4), `roster` (3), `partial_expected` (4:
+  `delincuencia_comunal`, `finanzas_municipales`, `indicadores_urbanos_siedu`,
+  `resultados_educacionales`), `partial` (2: `geometria_comunal`,
+  `pobreza_comunal`).
+
+- **`build_degradation`** (`metadata.py:117-158`): tras los casos especiales de
+  fallback, `if warnings: return {"status": "warning", ...}`. Todo warning pesa
+  igual. Los 3 warnings "por diseño" se emiten en `src/validation.py:530`
+  (SIEDU), `:931` (pobreza SAE) y `:1114` (partidos/SERVEL).
+
+- **`source_mode` de la capa derivada** — `metadata.py:488-503`:
+
+  ```python
+  "source_mode": "live"
+  if all(
+      metadata.get("source_mode") == "live"
+      for metadata in (comunas_metadata, ..., finanzas_metadata, ...)
+  )
+  else "fallback",
+  ```
+
+  `scripts/verify_pipeline.py:108-113` ya define
+  `VALID_SOURCE_MODES = {"live", "fallback", "monthly"}` y
+  `NON_FALLBACK_SOURCE_MODES = {"live", "monthly"}`, con el comentario explícito
+  de que `monthly` es "genuinamente obtenido de la fuente". El predicado de arriba
+  contradice esa definición.
+
+- **`severity` de `hub_health`** — `src/chile_hub/pipeline_status_utils.py:241-247`:
+
+  ```python
+  severity = "ok"
+  if validation_status != "ok":        severity = "error"
+  elif freshness_status in {"stale", "unknown"}: severity = "warn"
+  elif source_mode == "fallback" or warning_count > 0: severity = "warn"
+  ```
+
+- **Gates de enum** (no los relajes): `drift_status ∈ {healthy, drifted}` se valida
+  en `scripts/verify_pipeline.py` líneas 654, 901, 1124, 1317, 1412, 1511;
+  `coverage_status` en 893, 1119, 1312, 1418, 1506; `source_mode` contra
+  `VALID_SOURCE_MODES`. **Este plan no agrega valores a ningún enum.**
+
+- **Landing**: `app.js:120` mapea `fallback: "respaldo"`; `app.js:178` decide el
+  badge de atención con `drift?.status === "drifted" || degradation?.status ===
+  "warning" | "degraded"`; `app.js:659-688` renderiza `fallback_count`,
+  `drifted_count` y las píldoras `source_mode` / `coverage_status` / `drift_status`.
+
+## Comandos que vas a necesitar
+
+| Propósito | Comando | Resultado esperado |
+|---|---|---|
+| Build de artefactos | `make build` | exit 0 |
+| Verificación de integridad | `make verify` | exit 0 |
+| Tests focales | `uv run pytest tests/test_pipeline_logic.py tests/test_verify_pipeline.py -v` | todos pasan |
+| Regresión completa | `make test` | exit 0 |
+| Landing sincronizada | `make verify-landing` | exit 0 |
+| Calidad | `make lint && make format-check` | exit 0 |
+| Gate global | `make doctor` | exit 0 |
+
+## Alcance
+
+**En alcance**:
+
+- `src/builders/metadata.py` — `build_coverage`, `build_degradation`, `build_drift`
+  y el `source_mode` de `perfil_territorial_comunal`.
+- `src/chile_hub/pipeline_status_utils.py` — `build_hub_health` (severity).
+- `src/builders/reports.py` — contadores de `build_drift_report` si cambian de
+  semántica.
+- `src/validation.py` — **sólo** para marcar como esperados los 3 warnings ya
+  existentes (líneas 530, 931, 1114). Ninguna regla de validación nueva ni
+  eliminada.
+- `contracts/datasets/pobreza_comunal.schema.json` — evaluar `partial` →
+  `partial_expected` (ver Step 2).
+- `scripts/verify_pipeline.py` — gates para los campos nuevos.
+- `app.js` / `index.html` — vocabulario y badge de atención.
+- Tests, `docs/datasets/`, ADR-013, `plans/README.md`.
+
+**Fuera de alcance**:
+
+- **Los 3 problemas de datos reales**: `empresas` (RUT inválido), `indicadores`
+  (`ipc` reusado) y `consumo_electrico_comunal` (fuente muerta). Van como issues
+  separados (Step 6); son de otra naturaleza y no deben mezclarse con un cambio
+  de taxonomía.
+- Agregar valores a `VALID_SOURCE_MODES`, a `coverage_status` o un tercer
+  `drift_status`.
+- Correr extractores (`make extract` / `make refresh`), tocar `data/raw/`,
+  cambiar reglas de validación, o el historial de salud (Plan 063).
+
+## Git workflow
+
+- Branch: `advisor/066-drift-taxonomy`
+- Commits sugeridos, uno por paso: `fix(metadata): …`, `feat(health): …`
+- No hagas push ni merge sin instrucción explícita del operador.
+
+## Pasos
+
+### Step 0: Reproduce el baseline antes de tocar nada
+
+Todos los conteos de este plan (8 drifted, 7 warn) salen del snapshot de
+`data/normalized/` con fecha **2026-07-21**, que llegó por un commit de refresh
+diario de CI. Tu `data/staging/` local (30 archivos al momento de escribir esto)
+puede provenir de otro build. Si el baseline no reproduce, el primer `verify` del
+Step 1 falla por razones ajenas al cambio y vas a perseguir un fantasma.
+
+Corre `make build && make verify` **sin ninguna modificación** y confirma:
+
+```
+python3 -c "import json; d=json.load(open('data/normalized/hub_health.json')); print(d['dataset_count'], d['drifted_count'], d['warn_count'], d['overall_status'])"
+```
+
+→ `19 8 7 warn`, y que los 8 drifted sean exactamente `indicadores`,
+`finanzas_municipales`, `indicadores_urbanos_siedu`, `perfil_territorial_comunal`,
+`empresas`, `pobreza_comunal`, `consumo_electrico_comunal`, `partidos_politicos`.
+
+**Si no reproduce, DETENTE y repórtalo.** A partir de aquí el 8→3 es un delta
+contra un baseline verificado, no contra un JSON en disco. No corras `make
+extract` ni `make refresh` para "arreglar" el baseline.
+
+### Step 1: Corrige el `source_mode` de la capa derivada
+
+`monthly` ya está definido en el repo como fuente genuina
+(`NON_FALLBACK_SOURCE_MODES`), pero el predicado de
+`perfil_territorial_comunal` exige `== "live"` en los 9 upstreams. Con
+`finanzas_municipales` en `monthly`, la capa derivada se declara `fallback`
+teniendo 346/346 filas y cero warnings.
+
+Reemplaza la comparación literal por pertenencia al conjunto no-fallback. Importa
+el conjunto desde un único lugar (o defínelo en `metadata.py` y haz que
+`verify_pipeline.py` lo consuma) para que no queden dos definiciones capaces de
+divergir — CLAUDE.md regla anti-drift.
+
+No agregues un `source_mode: "derived"`. La derivación ya está expresada en
+`source_detail: "derived_from_validated_chile_hub_layers"` y en
+`notes: ["derived_dataset", "upstreams: …"]`; un enum nuevo cuesta seis gates y no
+compra información.
+
+**Verifica**: `make build && python3 -c "import json; d=json.load(open('data/normalized/drift_report.json')); e=[x for x in d['datasets'] if x['dataset']=='perfil_territorial_comunal'][0]; print(e['source_mode'], e['drift_status'])"`
+→ `live healthy`. Y un test unitario que fije el contrato: con un upstream en
+`monthly` y el resto en `live`, la capa derivada **no** es `fallback`; con un
+upstream en `fallback` real, **sí** lo es.
+
+### Step 2: Haz que `build_coverage` honre el `coverage_policy` del contrato
+
+`coverage_policy` ya existe en los 22 contratos y hoy se ignora. Conéctalo:
+
+1. En `build_coverage`, carga el contrato (o recibe el ya cargado desde
+   `enrich_dataset_metadata`, que lo tiene en `metadata.py:263` — preferible, para
+   no duplicar I/O).
+2. Cuando el resultado sea `status: "partial"` **y** `coverage_policy ==
+   "partial_expected"`, agrega al dict de coverage un campo booleano nuevo
+   **`expected: true`** con un `expected_reason` textual. **No cambies el valor de
+   `status`**: el enum está gateado en cinco puntos de `verify_pipeline.py` y
+   `partial` sigue siendo la descripción correcta de la cobertura.
+3. Cuando el `status` no sea `partial`, emite `expected: false` de forma explícita
+   (nunca ausente) para que el campo sea siempre inspeccionable.
+4. Mantén la rama existente que lee `partial_expected` desde el metadata del
+   extractor (SIEDU); ahora debe producir el mismo `expected: true`. Las dos rutas
+   convergen en un solo campo.
+
+Sobre `pobreza_comunal`: su contrato dice `coverage_policy: "partial"` pero su
+propio warning dice "parcial por diseño; comunas sin muestra no tienen
+estimación". Su `coverage_status` es `not_applicable` (no tiene
+`expected_record_count`), así que su drift viene del Step 3, no de aquí. Corrige
+el contrato a `partial_expected` **sólo** si documentas la justificación en
+`docs/datasets/pobreza_comunal.md`; si no, déjalo y anótalo como pregunta abierta
+en el ADR. Lo mismo aplica a `geometria_comunal`.
+
+**Alcance real: cuatro datasets, no dos.** `coverage_policy: "partial_expected"`
+está en **4** contratos: `finanzas_municipales`, `indicadores_urbanos_siedu`,
+`resultados_educacionales` y `delincuencia_comunal`. Sólo los dos primeros están
+hoy en el set drifted; los otros dos calculan `coverage_status` distinto de
+`partial` (sin `expected_record_count`, o actual ≥ esperado), así que el flag les
+queda **inerte por ahora**. Eso no los excluye del cambio: si alguno pasara a
+`partial` en un build futuro, quedaría `expected: true` y dejaría de driftar sin
+que ningún test lo haya ejercitado. Trátalos como parte del alcance desde el
+inicio.
+
+**Verifica**: los **4** datasets con `coverage_policy: "partial_expected"` quedan
+con `coverage.expected == true` cuando su cobertura es `partial`; para
+`resultados_educacionales` y `delincuencia_comunal` documenta en el test que hoy
+el flag es inerte y por qué. Los de `coverage_policy: "full"` quedan con
+`expected == false`. Test unitario por cada valor de `coverage_policy`
+(`full`, `not_applicable`, `roster`, `partial`, `partial_expected`).
+
+### Step 3: Distingue warnings informativos de warnings accionables
+
+Tres warnings describen diseño confirmado, no degradación:
+`src/validation.py:530` (SIEDU urbano), `:931` (cobertura SAE) y `:1114`
+(`estado_legal` vía SERVEL).
+
+Marca el origen, no el consumidor — clasificar por regex sobre el texto en
+`build_degradation` se rompe la primera vez que alguien reformule el mensaje.
+Diseño requerido:
+
+1. El dict que devuelven los validadores gana una lista `expected_warnings` con el
+   subconjunto de `warnings` que es informativo. **`warnings` sigue conteniendo
+   todos los mensajes**, sin excepción: es el registro transparente y hay gates y
+   tests que lo asumen.
+2. `build_degradation` calcula los accionables como `warnings` menos
+   `expected_warnings`. Devuelve `status: "warning"` sólo si quedan accionables;
+   si todos eran esperados, `status: "none"` con un `impact` que **enumere los
+   warnings esperados** (no los escondas: "3 observaciones esperadas: …") y
+   `recommended_action: "Ninguna."`.
+3. `build_hub_health` gana `actionable_warning_count` junto al `warning_count`
+   existente, y la línea de severity (`pipeline_status_utils.py:246`) pasa a usar
+   el accionable. `warning_count` no cambia de significado en ningún artefacto.
+
+**Verifica**: `pobreza_comunal` y `partidos_politicos` quedan
+`degradation: none`, `drift: healthy`, `severity: ok`, con `warning_count: 1` y
+`actionable_warning_count: 0`. `empresas` sigue en `warning` / `drifted` /
+`warn` con sus 3 warnings accionables. Test que pruebe que un warning **no**
+declarado como esperado sigue degradando (evita que esto se vuelva un silenciador
+genérico).
+
+### Step 4: Actualiza `build_drift` y los gates
+
+Con los campos nuevos en su lugar, `build_drift` (`metadata.py:221-253`) pasa a:
+
+- no marcar drift por cobertura cuando `coverage.expected is True`;
+- seguir marcando drift por `source_mode == "fallback"`, por
+  `coverage_status == "unknown"` y por `degradation_status ∈ {warning, degraded}`
+  (que ahora ya sólo refleja accionables);
+- cuando marque drift, que el `summary` diga cuál de las tres condiciones lo
+  disparó, no las tres a la vez.
+
+En `scripts/verify_pipeline.py` agrega gates para los campos nuevos:
+`coverage.expected` booleano y presente siempre; `actionable_warning_count`
+entero y `<= warning_count`. **No toques** las validaciones de enum existentes.
+
+**Ya verificado (2026-07-26): `verify_pipeline.py` no valida conjuntos exactos de
+claves.** Los bloques `REQUIRED_*` (p. ej. `scripts/verify_pipeline.py:1085-1093`)
+recorren claves obligatorias con `if health.get(key) is None: fail(...)`, y los
+enums usan pertenencia (`not in {...}`). El único conjunto exacto es de **nombres
+de dataset**, no de claves: `if dataset_names != REQUIRED_DATASETS`
+(`verify_pipeline.py:1096-1098`). Por lo tanto agregar `coverage.expected` y
+`actionable_warning_count` **no rompe `make verify`** por sí solo, y este paso es
+"agregar gates", no "registrar claves y luego agregar gates".
+
+**Verifica**: `make build && make verify` → exit 0, y
+`python3 -c "import json; d=json.load(open('data/normalized/hub_health.json')); print(d['drifted_count'], d['warn_count'], d['overall_status'])"`
+→ `3 3 warn`. Los 3 restantes deben ser exactamente `empresas`, `indicadores` y
+`consumo_electrico_comunal`. **Si el conteo no da exactamente eso, DETENTE**: o
+quedó un caso sin clasificar o silenciaste uno de más.
+
+### Step 5: Sincroniza landing, documentación y ADR
+
+- `app.js:178`: el badge de atención debe usar los accionables, no
+  `degradation?.status` a secas — si no, el drawer seguirá marcando datasets ya
+  clasificados como sanos.
+- Píldoras de `app.js:684-688`: la cobertura parcial esperada debe distinguirse
+  visualmente de la parcial inesperada (p. ej. `partial` vs `partial esperada`).
+  El vocabulario en español ya vive en el mapa de `app.js:120`.
+- Corre `make verify-landing` y `python3 scripts/check_landing_sync.py` (el gate
+  agregado el 2026-07-26): un cambio de vocabulario que no pase por ahí se
+  convierte en deriva silenciosa.
+- Escribe **ADR-013** (el siguiente libre; el último es ADR-012) documentando:
+  por qué no se agregó un tercer `drift_status`, por qué `warnings` conserva todos
+  los mensajes, quién puede declarar un warning como esperado, y las preguntas
+  abiertas de `pobreza_comunal` / `geometria_comunal` del Step 2.
+- Actualiza `docs/datasets/` de los 5 datasets reclasificados explicando que su
+  parcialidad es de diseño, y `docs/backlog/05-dashboard-publico-salud.md` si
+  describe la semántica vieja.
+
+**Verifica**: `make verify-landing && make doctor` → exit 0.
+
+### Step 6: Registra los 3 problemas reales como trabajo separado
+
+No los arregles aquí. Abre un issue por cada uno, con el diagnóstico ya conocido:
+
+1. **`empresas`** — `found 1 RUTs with invalid format`. Decidir si se descarta la
+   fila, se corrige el DV o se acepta como ruido conocido de la fuente CKAN.
+2. **`indicadores`** — `live refresh reused last published artifact for missing
+   codes: ipc`. Investigar por qué falta `ipc` en el refresh live.
+3. **`consumo_electrico_comunal`** — CNE decomisionó el catálogo Junar
+   (permanente desde 2026-07-07, AGENTS.md §6); quedan 3 filas de muestra. La
+   decisión es de producto: deprecar el dataset, buscar fuente de reemplazo, o
+   declararlo retirado. **No es reparable por código** y su `drifted` actual es
+   correcto — debe seguir apareciendo en rojo.
+
+**Verifica**: los 3 issues existen y este plan los referencia por número.
+
+## Test plan
+
+- `source_mode` derivado: upstream `monthly` no contamina; upstream `fallback` sí.
+- `build_coverage` para cada valor de `coverage_policy` (`full`,
+  `not_applicable`, `roster`, `partial`, `partial_expected`), incluida la ruta del
+  metadata del extractor (SIEDU).
+- `build_degradation`: sólo esperados → `none`; mezcla → `warning` con los
+  accionables en `impact`; warning no declarado → `warning`.
+- `build_drift`: parcial esperada no drifta; parcial inesperada sí; `unknown` sí;
+  fallback sí.
+- `build_hub_health`: `warning_count` intacto, `actionable_warning_count` nuevo,
+  severity derivada del accionable.
+- `verify_pipeline`: los gates nuevos fallan ante campos ausentes o
+  `actionable_warning_count > warning_count`.
+- Regresión de artefactos: `make build && make verify && make test`.
+- Guardrail: un test que fije `drifted_count == 3` sobre el fixture, para que una
+  regresión futura de clasificación sea ruidosa.
+
+## Done criteria
+
+- [ ] El baseline del Step 0 reprodujo `19 8 7 warn` con los 8 datasets esperados
+      **antes** de la primera modificación.
+- [ ] `drifted_count` baja de 8 a **3**, y esos 3 son `empresas`, `indicadores` y
+      `consumo_electrico_comunal`.
+- [ ] Los **4** contratos con `coverage_policy: "partial_expected"` están cubiertos
+      por tests, incluidos los dos donde el flag es inerte hoy.
+- [ ] `warn_count` baja de 7 a **3**; `overall_status` sigue siendo `warn`.
+- [ ] Ningún enum (`drift_status`, `coverage_status`, `source_mode`) ganó valores.
+- [ ] Ningún gate de `verify_pipeline.py` fue relajado; se agregaron gates para los
+      campos nuevos.
+- [ ] `warnings` sigue conteniendo todos los mensajes en todos los artefactos.
+- [ ] Cero cambios en `data/raw/`, en reglas de validación y en datos extraídos.
+- [ ] `make build && make verify && make test && make verify-landing && make lint && make format-check && make doctor` → todos exit 0.
+- [ ] ADR-013 escrito; `docs/datasets/` de los 5 reclasificados actualizados.
+- [ ] Los 3 issues del Step 6 abiertos y referenciados.
+- [ ] `tests/e2e/verify_066.sh` escrito y en verde.
+
+## STOP conditions
+
+- Bajar un contador exige tocar datos, `data/raw/`, o eliminar/relajar una regla
+  de validación.
+- Un enum gateado necesitaría un valor nuevo para que el diseño funcione.
+- Tras el Step 4 el conteo no da exactamente 3 drifted con los 3 datasets
+  esperados.
+- Un dataset **sin** declaración de "esperado" en contrato o validador cambia de
+  `drifted` a `healthy` — eso es un silenciador, no una reclasificación.
+- `make verify-landing` o `check_landing_sync.py` fallan y la única salida
+  aparente es saltarse el gate.
+
+## Notas de mantenimiento
+
+El riesgo permanente de este cambio es que `expected_warnings` se convierta en un
+basurero donde se archiva cualquier warning molesto. Mitigación: la declaración
+vive junto a la regla que emite el warning (`validation.py`) o en el contrato
+(`coverage_policy`), nunca en el consumidor, y el ADR fija quién puede agregar una
+entrada y con qué justificación. En cada revisión de salud, audita la lista de
+esperados antes que la de accionables: un `drifted_count` que baja sin que baje el
+trabajo real es la falla de modo de este diseño.

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,6 +2,15 @@
 
 Planes de implementación generados por auditoría `/improve deep` en commits `ba2f434` (2026-06-13), `a2cd288` (2026-06-19) y `c486e7c` (2026-07-07), y por `/improve plan` (mejoras de librerías/dependencias) en commit `140c8ea` (2026-06-29).
 
+> **Auditoría `/improve next` — dirección/roadmap (2026-07-26, commit `63cc106`)**:
+> se revalidaron los cinco hallazgos con mayor palanca: resolución nombres→CUT
+> (**050**), acceso HTTP/DCAT (**051**), publicación de la geometría candidate
+> (**064**), resolución coordenadas→CUT (**065**), anomalías temporales (**054**) y
+> ownership catálogo→extractor (**058**). El Plan 053 dejó completos sus Steps 0–3;
+> sus dos entregables restantes se separan en 064/065 para aislar riesgos de CI y de
+> API runtime. No se propone un dataset nuevo: ADR-011 sigue priorizando profundidad
+> sobre fuentes oficiales existentes, no amplitud de fuentes frágiles.
+
 > **Auditoría `/improve next` — dirección/roadmap (2026-07-14, commit `7ebf94b`)**: planes
 > **050–052**. Foco exclusivo en la categoría *dirección* (hacia dónde llevar el proyecto),
 > no en bugs. Contexto: repo muy maduro — la lista "deseable post-MVP" del `product-spec`
@@ -112,12 +121,36 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 |---|------|----------|----------|--------|-----------|--------|
 | 050 | [Resolutor público `resolve_comunas()` (nombres → CUT)](050-resolve-comunas-name-to-cut.md) | P2 | M | LOW-MED | — | TODO — spike con entregable de código: resolutor determinista + `ADR-009`; fuzzy queda como pregunta abierta. |
 | 051 | [Capa de acceso HTTP estática + catálogo DCAT `data.json`](051-static-http-access-and-dcat-catalog.md) | P2 | M | LOW | — | TODO — spike: contrato + `ADR-010` + prototipo generador DCAT + fix `from_datapackage(url)` + docs. Sólo archivos estáticos, sin servidor. |
-| 053 | [Geometría comunal (GeoParquet) + `resolve_by_coords()` reverse geocoding](053-comuna-geometry-and-reverse-geocoding.md) | **P1** | L | MED | — (complementa 050) | 🔶 Steps 0-3 ✓ (2026-07-23) — ADR-011 **ratificado** (accepted) por Carlos Ortega. ADR-012 (`accepted`): gate de licencia PASA (fuente `tematico/Comunas_Generalizadas` en `arcgiswebad.bcn.cl`, uso libre con atribución). Extractor (345/346 comunas, fallback Magallanes), validador y writer GeoParquet 1.0 (WKB, EPSG:4326) implementados; carril `candidate`/`bajo_demanda` **fuera** de `make extract`/`build_dev_db.py` (patrón `delincuencia_comunal`), script standalone `scripts/build_geometria_comunal.py`. Commit `56cd9d5` en worktree `worktree-053-comuna-geometry`. Suite completa (681 tests) sin regresiones. **Pendiente**: el artefacto GeoParquet (5.1 MB) aún **no está publicado** — excede el límite de 500 KB de `check-added-large-files`, requiere decisión (subir el límite o workflow de CI dedicado, como `empresas.parquet`). Step 4 (`resolve_by_coords()`, extra `[geo]`) y el wiring de CI de Step 5 quedan **diferidos** a una sesión futura. |
+| 053 | [Geometría comunal — parent histórico](053-comuna-geometry-and-reverse-geocoding.md) | P1 | L | MED | — | SUPERSEDED — Steps 0–3 DONE (extractor, validación, writer, licencia y docs). Los pendientes se ejecutan exclusivamente como 064 y 065. |
 | 054 | [Validación de anomalías temporales sobre series numéricas](054-temporal-anomaly-validation-numeric-series.md) | P2 | M | MED | — | TODO — foso de confianza (no generador de demanda; respalda 053). Anomalía = warning + flag de drift + gate de publicación override-able, **nunca** `SystemExit` del build. Alcance inicial: `indicadores`. |
 | 057 | [Skeleton loading states + polish de interacción](057-loading-skeletons-and-interaction-polish.md) | P2 | M | LOW | — (055 recomendado) | TODO — skeletons para catálogo y KPIs, empty state de búsqueda, tarjetas clickeables, tecla Escape en drawer. |
-| 058 | [Campo `extractor` en el catálogo + tabla de extractores auto-generada en README](058-catalogo-campo-extractor-y-tabla-readme.md) | P2 | M | LOW | — | TODO — cierra el hueco que `AGENTS.md §12` nombra explícito: campo `extractor` en las 21 entradas + validación en `check_companion_paths registry` + `sync_readme_extractor_table()`. Disjunto de 050–057. |
+| 058 | [Campo `extractor` en el catálogo + tabla de extractores auto-generada en README](058-catalogo-campo-extractor-y-tabla-readme.md) | P2 | M | LOW | — | TODO — cierra el hueco que `AGENTS.md §12` nombra explícito: campo `extractor` en las 22 entradas + validación en `check_companion_paths registry` + `sync_readme_extractor_table()`. Disjunto de 050–057. |
+| 064 | [Publicar GeoParquet candidate desde CI](064-publish-geometry-artifact-from-ci.md) | **P1** | M | MED | — | IN PROGRESS — workflow manual, validación antes de commit y checksum implementados localmente; falta dispatch autorizado y lectura desde Pages para DONE. |
+| 065 | [Resolver coordenadas a comuna](065-add-coordinate-resolver.md) | **P1** | M | MED | 064 | TODO — extra opcional `geo`, cache con checksum y `resolve_by_coords()`; candidate nunca entra al bundle estable. |
 | 059 | [Publicación del bundle en Hugging Face Hub](059-publicacion-huggingface-hub.md) | P2 | M | MED | — (052 recomendado antes, no gate) | TODO — canal de *descubrimiento* (complementa 051 = capa de acceso). Script `--dry-run` + job `hf-publish` en `pypi-release.yml` + dataset card. Requiere secret `HF_TOKEN` (paso manual del mantenedor). Carril `candidate` excluido por construcción. |
 | 063 | [Historial de salud del hub + sparkline en landing](063-historial-salud-hub.md) | P3 | M | MED | — (054 recomendado antes) | TODO — `hub_health_history.jsonl` append-only (cap 400, idempotente por timestamp) + sparkline SVG en el dashboard. Primer artefacto acumulativo del pipeline — Step 1 verifica la premisa de persistencia con un probe. |
+| 066 | [Separar drift esperado de drift real](066-taxonomia-drift-esperado-vs-real.md) | P2 | M | MED | — (bloquea 063 en valor) | TODO — clasificación, **no** reparación de datos: `coverage_policy` del contrato hoy se ignora y todo warning pesa igual, así que 4 de 8 "drifted" son ruido estructural. Baja `drifted_count` 8→3 sin agregar valores a ningún enum ni relajar gates. Los 3 problemas de datos reales salen como issues separados. |
+
+## Orden de ejecución actualizado (2026-07-26)
+
+1. **064** — publica y verifica el artefacto que hoy falta; es el bloqueo real para la capacidad geoespacial.
+2. **051** — convierte el hosting estático ya existente en una superficie estándar y descubrible; puede avanzar mientras 064 espera revisión humana, pero debe integrar la URL publicada cuando exista.
+3. **065** — sólo después de 064: consume el GeoParquet y su checksum sin contaminar el bundle estable.
+4. **050**, **054** y **058** — independientes entre sí y de 064, salvo que no deben tocar los mismos archivos en paralelo. Recomendación de valor: 050 → 054 → 058.
+5. **059** y **063** conservan sus dependencias históricas; no son parte de los hallazgos de esta auditoría.
+6. **066** — independiente de todo lo anterior, pero conviene **antes de 063**: el historial de salud congelaría en JSONL una taxonomía que hoy clasifica mal 4 de 19 datasets. También cierra el pendiente "vocabulario del dashboard de salud" diferido en la auditoría 2026-07-13.
+
+### Dependencias de la auditoría 2026-07-26
+
+- 065 depende estrictamente de 064: sin una lectura remota exitosa y un checksum publicado, no hay contrato seguro de cache.
+- 051 y 064 deben coordinar la documentación de la URL estática, pero no se bloquean a nivel de código.
+- 054 sigue siendo el respaldo de confianza; no debe retrasar la publicación ni la API de geometría.
+- 050 y 065 modifican `src/chile_hub/core.py`; ejecútalos secuencialmente, no en worktrees paralelos.
+
+## Hallazgos considerados y rechazados (2026-07-26)
+
+- **Agregar un dataset nuevo**: rechazado por ahora. Las ideas restantes requieren fuentes o licencias aún no consolidadas; ADR-011 limita la estrategia actual a profundizar capacidad sobre la fuente BCN ya validada.
+- **Subir el límite global de 500 KB o saltar pre-commit**: rechazado. El flujo de CI de 064 resuelve la publicación de datos sin debilitar los controles locales para el código.
 
 ## Planes archivados (2026-07-24)
 

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -23,6 +23,7 @@ from check_companion_paths import check_companions
 PIPELINE_CHECK_WORKFLOW = ROOT_DIR / ".github" / "workflows" / "pipeline-check.yml"
 MONTHLY_SCRAPE_WORKFLOW = ROOT_DIR / ".github" / "workflows" / "monthly-scrape.yml"
 ADOPTION_STATS_WORKFLOW = ROOT_DIR / ".github" / "workflows" / "adoption-stats.yml"
+GEOMETRIA_COMUNAL_WORKFLOW = ROOT_DIR / ".github" / "workflows" / "geometria-comunal.yml"
 MAKEFILE = ROOT_DIR / "Makefile"
 MKDOCS_CONFIG = ROOT_DIR / "mkdocs.yml"
 DOCS_DIR = ROOT_DIR / "docs"
@@ -198,6 +199,77 @@ class LandingSyncGateGuardrailTests(unittest.TestCase):
             body,
             "`make doctor` debe correr el gate de landing antes de commit.",
         )
+
+
+class GeometriaCandidateWorkflowGuardrailTests(unittest.TestCase):
+    """La geometría comunal es candidate y supera el límite local de 500 KB.
+
+    Su publicación debe pasar por un workflow manual que valide el GeoParquet
+    antes de forzar exclusivamente los artefactos permitidos. Esto preserva el
+    guard de archivos grandes y evita que la geometría entre por accidente al
+    build diario o al bundle estable.
+    """
+
+    def setUp(self):
+        self.content = GEOMETRIA_COMUNAL_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_workflow_is_manual_only_with_locked_pipeline_dependencies(self):
+        self.assertIn("workflow_dispatch:", self.content)
+        self.assertNotIn("schedule:", self.content)
+        self.assertIn("contents: write", self.content)
+        self.assertIn("uv lock --locked", self.content)
+        self.assertIn("uv sync --extra pipeline --extra dev --locked", self.content)
+
+    def test_validates_standalone_builder_before_commit(self):
+        build_index = self.content.index("scripts/build_geometria_comunal.py")
+        validation_index = self.content.index("Validate candidate GeoParquet")
+        commit_index = self.content.index("Commit validated candidate artifacts")
+        self.assertLess(build_index, validation_index)
+        self.assertLess(validation_index, commit_index)
+        self.assertIn("gpd.read_parquet", self.content)
+        self.assertIn("frame.crs.to_epsg() == 4326", self.content)
+        self.assertIn("frame.geometry.is_empty.any()", self.content)
+        self.assertIn('frame["codigo_comuna"].is_unique', self.content)
+        self.assertIn("len(value) == 5 and value.isdigit()", self.content)
+        self.assertIn("len(value) == 2 and value.isdigit()", self.content)
+        self.assertIn('metadata.get("source_mode") == "live"', self.content)
+        self.assertIn("Missing staging CSV", self.content)
+        self.assertIn("Missing staging metadata", self.content)
+        self.assertIn("Missing raw BCN geometry snapshot", self.content)
+
+    def test_workflow_never_reuses_staging_or_publishes_fallback_data(self):
+        self.assertNotIn("--skip-fetch", self.content)
+        self.assertIn('metadata.get("source_mode") == "live"', self.content)
+
+    def test_commit_stages_only_allowed_geometry_artifacts_and_checksum(self):
+        expected_paths = [
+            "data/normalized/geometria_comunal.parquet",
+            "data/staging/geometria_comunal.csv",
+            "data/staging/geometria_comunal.metadata.json",
+            "data/normalized/geometria_comunal.parquet.sha256",
+            "data/raw/bcn_geometria_comunal_*.json",
+        ]
+        for path in expected_paths:
+            self.assertIn(path, self.content)
+        self.assertIn("sha256sum -c geometria_comunal.parquet.sha256", self.content)
+        self.assertIn('git add -f "$path"', self.content)
+        self.assertIn("[skip ci]", self.content)
+
+        commit_block = self.content.split("Commit validated candidate artifacts", 1)[1].split(
+            "- name: Summary", 1
+        )[0]
+        staged_paths = [
+            line.strip().rstrip("\\").strip()
+            for line in commit_block.splitlines()
+            if "data/" in line
+        ]
+        self.assertEqual(staged_paths, expected_paths)
+
+    def test_workflow_does_not_call_stable_pipeline_or_bundle(self):
+        self.assertNotIn("make build", self.content)
+        self.assertNotIn("make extract", self.content)
+        self.assertNotIn("package-bundle", self.content)
+        self.assertNotIn("build_dev_db.py", self.content)
 
 
 def _extract_make_target(makefile_content: str, target_name: str) -> str:


### PR DESCRIPTION
## Resumen
- agrega workflow manual y validado para publicar el GeoParquet candidate
- incorpora checksum consumible desde Pages y guardrails de CI
- actualiza documentación y roadmap de los planes 064–066

## Verificación
- make build && make verify
- pytest: 706 passed, 1 skipped
- make lint && make format-check && make doctor