### PR TITLE
feat: notify users about data updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ chile-hub cache status     # Ubicación y estado del cache local
 chile-hub cache clear      # Liberar espacio
 ```
 
+Cuando se usa la caché `latest`, el paquete consulta GitHub Releases como máximo una vez por semana para avisar si hay datos nuevos. La comprobación no envía información de uso ni afecta la carga de datos si no hay red. Para desactivarla, configura `CHILE_HUB_NO_UPDATE_CHECK=1`; `CHILE_HUB_LANG=es|en` permite elegir el idioma del aviso.
+
 > **Variante para desarrolladores del pipeline:** `pip install chile-hub[pipeline]` agrega DuckDB, Pandas, XlsxWriter y curl_cffi para ejecutar el pipeline completo de extracción y build. La instalación mínima solo incluye Polars, PyArrow, requests y platformdirs — suficiente para consumir datos.
 
 > [!NOTE]
@@ -204,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **805 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **810 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,6 +29,8 @@ chile-hub cache clear
 
 Configura `CHILE_HUB_CACHE_DIR` para sobrescribir la ubicación de la caché.
 
+Con la caché `latest`, chile-hub consulta GitHub Releases como máximo una vez por semana para avisar si existe una versión más reciente de los datos. No envía información de uso y los problemas de red no interrumpen la carga. Configura `CHILE_HUB_NO_UPDATE_CHECK=1` para desactivarlo o `CHILE_HUB_LANG=es|en` para elegir el idioma del aviso.
+
 ## Artefactos locales y sin conexión
 
 Para uso sin conexión, puebla la caché antes de desconectarte:

--- a/src/chile_hub/core.py
+++ b/src/chile_hub/core.py
@@ -2272,7 +2272,7 @@ def _main(argv=None):  # pragma: no cover — dispatch de CLI, testeado vía smo
             print(json.dumps(manager.status(), ensure_ascii=False, indent=2))
             return
         if args.cache_command == "update":
-            data_dir = manager.ensure_data_dir(auto_update=True)
+            data_dir = manager.update()
             print(data_dir)
             return
         if args.cache_command == "clear":

--- a/src/chile_hub/data_manager.py
+++ b/src/chile_hub/data_manager.py
@@ -7,8 +7,10 @@ import json
 import os
 import shutil
 import tempfile
+import warnings
 import zipfile
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -21,12 +23,23 @@ DEFAULT_REPOSITORY = "cortega26/chile-hub"
 DEFAULT_BUNDLE_NAME = "chile-hub-publishable-bundle.zip"
 DEFAULT_CHECKSUM_NAME = "chile-hub-publishable-bundle.zip.sha256"
 ENV_CACHE_DIR = "CHILE_HUB_CACHE_DIR"
+ENV_DISABLE_UPDATE_CHECK = "CHILE_HUB_NO_UPDATE_CHECK"
+ENV_LANGUAGE = "CHILE_HUB_LANG"
+UPDATE_CHECK_INTERVAL = timedelta(days=7)
+UPDATE_CHECK_TIMEOUT = 3
+UTC = timezone.utc
+SUPPORT_URL = f"https://github.com/sponsors/{DEFAULT_REPOSITORY.split('/')[0]}"
+BUY_ME_A_COFFEE_URL = f"https://www.buymeacoffee.com/{DEFAULT_REPOSITORY.split('/')[0]}"
 
 
 @dataclass(frozen=True)
 class ReleaseAsset:
     name: str
     url: str
+
+
+class ChileHubUpdateWarning(UserWarning):
+    """Avisa que existe una nueva versión de los datos publicados."""
 
 
 class ChileHubDataManager:
@@ -57,6 +70,11 @@ class ChileHubDataManager:
     def marker_path(self) -> Path:
         return self.version_cache_dir / ".verified.json"
 
+    @property
+    def update_check_path(self) -> Path:
+        """Ruta del estado local del chequeo periódico de actualizaciones."""
+        return self.version_cache_dir / ".update_check.json"
+
     def status(self) -> dict[str, Any]:
         """Estado del caché local de datos: versión, rutas y si está listo para usarse."""
         catalog_path = self.normalized_dir / "dataset_catalog.json"
@@ -84,6 +102,7 @@ class ChileHubDataManager:
             ChileHubDataError: Si auto_update es False y no existe caché local verificado.
         """
         if (self.normalized_dir / "dataset_catalog.json").exists() and self.marker_path.exists():
+            self._check_for_update_if_due()
             return self.normalized_dir
         if not auto_update:
             raise ChileHubDataError(
@@ -190,7 +209,120 @@ class ChileHubDataManager:
             return  # nothing to clear
         shutil.rmtree(str(cache_path))
 
-    def _resolve_release(self) -> dict[str, Any]:
+    def _check_for_update_if_due(self) -> None:
+        """Avisa semanalmente si el bundle ``latest`` quedó desactualizado.
+
+        Es una comprobación de mejor esfuerzo: no envía telemetría ni interrumpe
+        el consumo de datos si GitHub, la red o el estado local no están disponibles.
+        """
+        if self.data_version != "latest" or self._update_checks_disabled():
+            return
+
+        state = self._read_json(self.update_check_path)
+        if not self._is_update_check_due(state):
+            return
+
+        checked_at = datetime.now(UTC)
+        try:
+            release = self._resolve_release(timeout=UPDATE_CHECK_TIMEOUT)
+            latest_tag = release.get("tag_name")
+            if not isinstance(latest_tag, str) or not latest_tag:
+                raise ValueError("GitHub release response does not include tag_name")
+
+            marker = self._read_json(self.marker_path)
+            current_tag = marker.get("release", {}).get("tag_name")
+            self._write_json(
+                self.update_check_path,
+                {
+                    "checked_at_utc": checked_at.isoformat(),
+                    "latest_tag": latest_tag,
+                    "status": "ok",
+                },
+            )
+        except Exception:
+            # Esta consulta es opcional: recordar el intento evita reintentos en
+            # cada inicialización si el usuario está sin conectividad.
+            try:
+                self._write_json(
+                    self.update_check_path,
+                    {
+                        "checked_at_utc": checked_at.isoformat(),
+                        "status": "unavailable",
+                    },
+                )
+            except OSError:
+                pass
+            return
+
+        if isinstance(current_tag, str) and current_tag and current_tag != latest_tag:
+            warnings.warn(
+                self._format_update_notice(current_tag=current_tag, latest_tag=latest_tag),
+                ChileHubUpdateWarning,
+                stacklevel=3,
+            )
+
+    @staticmethod
+    def _update_checks_disabled() -> bool:
+        value = os.environ.get(ENV_DISABLE_UPDATE_CHECK, "")
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _is_update_check_due(state: dict[str, Any]) -> bool:
+        checked_at = state.get("checked_at_utc")
+        if not isinstance(checked_at, str):
+            return True
+        try:
+            parsed = datetime.fromisoformat(checked_at)
+        except ValueError:
+            return True
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+
+        now = datetime.now(UTC)
+        return parsed > now or now - parsed >= UPDATE_CHECK_INTERVAL
+
+    @staticmethod
+    def _preferred_language() -> str:
+        """Retorna ``en`` solo para una preferencia inglesa explícita; español es el fallback."""
+        language = os.environ.get(ENV_LANGUAGE)
+        if not language:
+            language = (
+                os.environ.get("LC_ALL")
+                or os.environ.get("LC_MESSAGES")
+                or os.environ.get("LANG")
+                or ""
+            )
+        return "en" if language.lower().startswith("en") else "es"
+
+    @classmethod
+    def _format_update_notice(cls, *, current_tag: str, latest_tag: str) -> str:
+        if cls._preferred_language() == "en":
+            return (
+                f"A new chile-hub data release is available: {latest_tag}\n"
+                f"Cached version: {current_tag}\n\n"
+                "Update it with:\n"
+                "    chile-hub cache update\n\n"
+                "chile-hub is an independent project developed and maintained by one person, "
+                "without institutional sponsors or affiliations. This independence lets it "
+                "prioritize verifiable data and deliver an objective, impartial, useful, "
+                "high-quality tool.\n\n"
+                "If chile-hub is useful to you, consider supporting its development and "
+                f"maintenance financially:\n{SUPPORT_URL}\n{BUY_ME_A_COFFEE_URL}"
+            )
+        return (
+            f"Hay una nueva versión de los datos de chile-hub: {latest_tag}\n"
+            f"Versión almacenada localmente: {current_tag}\n\n"
+            "Actualízala ejecutando:\n"
+            "    chile-hub cache update\n\n"
+            "chile-hub es un proyecto independiente, desarrollado y mantenido por una sola "
+            "persona, sin patrocinadores institucionales ni afiliaciones. Esta independencia "
+            "permite priorizar datos verificables y ofrecer una herramienta objetiva, "
+            "imparcial, útil y de calidad.\n\n"
+            "Si chile-hub te resulta útil, puedes apoyar económicamente su desarrollo y "
+            f"mantenimiento:\n{SUPPORT_URL}\n{BUY_ME_A_COFFEE_URL}"
+        )
+
+    def _resolve_release(self, *, timeout: float = 30) -> dict[str, Any]:
         suffix = (
             "releases/latest"
             if self.data_version == "latest"
@@ -200,7 +332,7 @@ class ChileHubDataManager:
         response = self.session.get(
             url,
             headers={"Accept": "application/vnd.github+json"},
-            timeout=30,
+            timeout=timeout,
         )
         if response.status_code != 200:
             raise ChileHubDataError(
@@ -260,3 +392,11 @@ class ChileHubDataManager:
         if not path.exists():
             return {}
         return json.loads(path.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
+
+    @staticmethod
+    def _write_json(path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )

--- a/tests/test_chile_hub.py
+++ b/tests/test_chile_hub.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import json
 import os
 import shutil
@@ -6,11 +7,13 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import warnings
 import zipfile
+from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import polars as pl
 
@@ -30,7 +33,8 @@ from chile_hub import (
     ChileHubExampleError,
     ChileHubOutputError,
 )
-from chile_hub.data_manager import ChileHubDataManager, ReleaseAsset
+from chile_hub.core import _main
+from chile_hub.data_manager import ChileHubDataManager, ChileHubUpdateWarning, ReleaseAsset
 from src.validation import validate_indicadores
 
 # ── Staleness guard ───────────────────────────────────────────────────────────
@@ -2074,6 +2078,95 @@ class ChileHubDataManagerUnitTests(unittest.TestCase):
         """_read_json() con archivo inexistente retorna {}."""
         result = ChileHubDataManager._read_json(Path("/tmp/no_existe_xyz_123.json"))
         self.assertEqual(result, {})
+
+    def test_ready_latest_cache_notifies_once_when_new_release_is_available(self):
+        """La caché latest consulta una vez por semana y avisa en español por defecto."""
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = {"tag_name": "v9.9.9"}
+        session = Mock()
+        session.get.return_value = response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ChileHubDataManager(cache_dir=tmpdir, session=session)
+            manager.normalized_dir.mkdir(parents=True)
+            (manager.normalized_dir / "dataset_catalog.json").write_text("{}", encoding="utf-8")
+            manager.marker_path.write_text(
+                json.dumps({"release": {"tag_name": "v1.0.0"}}), encoding="utf-8"
+            )
+
+            with (
+                patch.dict(os.environ, {"CHILE_HUB_LANG": "es"}, clear=False),
+                warnings.catch_warnings(record=True) as caught,
+            ):
+                warnings.simplefilter("always", ChileHubUpdateWarning)
+                self.assertEqual(manager.ensure_data_dir(), manager.normalized_dir)
+
+            self.assertEqual(len(caught), 1)
+            message = str(caught[0].message)
+            self.assertIn("Hay una nueva versión", message)
+            self.assertIn("apoyar económicamente", message)
+            self.assertIn("https://github.com/sponsors/cortega26", message)
+            self.assertIn("https://www.buymeacoffee.com/cortega26", message)
+            self.assertEqual(session.get.call_args.kwargs["timeout"], 3)
+            self.assertEqual(
+                json.loads(manager.update_check_path.read_text(encoding="utf-8"))["latest_tag"],
+                "v9.9.9",
+            )
+
+    def test_ready_cache_skips_update_check_before_week_has_elapsed(self):
+        """El estado local evita una consulta de red en cada inicialización."""
+        session = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ChileHubDataManager(cache_dir=tmpdir, session=session)
+            manager.normalized_dir.mkdir(parents=True)
+            (manager.normalized_dir / "dataset_catalog.json").write_text("{}", encoding="utf-8")
+            manager.marker_path.write_text("{}", encoding="utf-8")
+            manager.update_check_path.write_text(
+                json.dumps({"checked_at_utc": datetime.now(UTC).isoformat()}), encoding="utf-8"
+            )
+
+            self.assertEqual(manager.ensure_data_dir(), manager.normalized_dir)
+
+        session.get.assert_not_called()
+
+    def test_update_check_opt_out_prevents_network_request(self):
+        """CHILE_HUB_NO_UPDATE_CHECK desactiva por completo la comprobación opcional."""
+        session = Mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ChileHubDataManager(cache_dir=tmpdir, session=session)
+            manager.normalized_dir.mkdir(parents=True)
+            (manager.normalized_dir / "dataset_catalog.json").write_text("{}", encoding="utf-8")
+            manager.marker_path.write_text("{}", encoding="utf-8")
+
+            with patch.dict(os.environ, {"CHILE_HUB_NO_UPDATE_CHECK": "1"}, clear=False):
+                self.assertEqual(manager.ensure_data_dir(), manager.normalized_dir)
+
+        session.get.assert_not_called()
+
+    def test_update_notice_uses_english_for_english_locale(self):
+        """La variable de idioma explícita traduce el mensaje para usuarios en inglés."""
+        with patch.dict(os.environ, {"CHILE_HUB_LANG": "en_US"}, clear=False):
+            message = ChileHubDataManager._format_update_notice(
+                current_tag="v1.0.0", latest_tag="v9.9.9"
+            )
+
+        self.assertIn("A new chile-hub data release is available", message)
+        self.assertIn("supporting its development", message)
+
+    def test_cache_update_cli_forces_bundle_download(self):
+        """cache update debe descargar aun cuando ya exista una caché verificada."""
+        with patch("chile_hub.core.ChileHubDataManager") as manager_class:
+            manager_class.return_value.update.return_value = Path("/tmp/chile-hub-data")
+            output = io.StringIO()
+            with redirect_stdout(output):
+                _main(["cache", "update"])
+
+        manager_class.return_value.update.assert_called_once_with()
+        manager_class.return_value.ensure_data_dir.assert_not_called()
+        self.assertIn("/tmp/chile-hub-data", output.getvalue())
 
     def test_cache_clear_when_not_exists_returns_early(self):
         """clear() cuando el caché no existe retorna sin error."""


### PR DESCRIPTION
## Qué cambia

- Consulta semanal y opcional de GitHub Releases para avisar sobre datos nuevos.
- Aviso en español por defecto, con detección/configuración de idioma y opt-out.
- Llamado de apoyo económico usando GitHub Sponsors y Buy Me a Coffee.
- `chile-hub cache update` ahora fuerza la descarga de una caché existente.

## Validación

- `pytest tests/test_chile_hub.py tests/test_packaging_runtime.py -q` — 184 passed
- Ruff y sincronización documental correctos.