### PR TITLE
fix(release): degrada a ready=false cuando la re-verificacion falla

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -189,14 +189,12 @@ jobs:
           print(p.get("allow_stale_backfills", ""))
           PY
           )"
-              if [[ -n "$stale_backfills" ]]; then
-                python scripts/verify_pipeline.py --profile release \
-                  --allow-stale-backfills "$stale_backfills"
-              else
-                python scripts/verify_pipeline.py --profile release
-              fi
-              recheck_status="$?"
-              if [[ "$recheck_status" -eq 0 ]]; then
+              # `if` (no capturar $?): el step corre bajo `set -e`, y con un
+              # fallo de verify_pipeline bash moriria ANTES de asignar el exit
+              # code — el ready=false nunca se emitiria y el release abortaria
+              # igual (regresion 2026-08-11, detectada en review PR #57).
+              if python scripts/verify_pipeline.py --profile release \
+                  ${stale_backfills:+--allow-stale-backfills "$stale_backfills"}; then
                 echo "ready=true" >> "$GITHUB_OUTPUT"
               else
                 # La re-verificacion fallo (p. ej. el artefacto publication-grade
@@ -205,7 +203,7 @@ jobs:
                 # paquete PyPI se publica igual; solo no se adjuntan datos.
                 # Regresion 2026-08-11 (run 31544671830): abortar aqui mataba el
                 # release completo en vez de degradar a ready=false.
-                echo "::notice::El artefacto publication-grade no paso la re-verificacion del release (exit $recheck_status); el paquete se publica sin adjuntar datos."
+                echo "::notice::El artefacto publication-grade no paso la re-verificacion del release; el paquete se publica sin adjuntar datos."
                 echo "ready=false" >> "$GITHUB_OUTPUT"
               fi
               ;;

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -195,7 +195,19 @@ jobs:
               else
                 python scripts/verify_pipeline.py --profile release
               fi
-              echo "ready=true" >> "$GITHUB_OUTPUT"
+              recheck_status="$?"
+              if [[ "$recheck_status" -eq 0 ]]; then
+                echo "ready=true" >> "$GITHUB_OUTPUT"
+              else
+                # La re-verificacion fallo (p. ej. el artefacto publication-grade
+                # mas reciente quedo stale entre el publish y el release, o su
+                # provenance es de antes de que el override se registrara). El
+                # paquete PyPI se publica igual; solo no se adjuntan datos.
+                # Regresion 2026-08-11 (run 31544671830): abortar aqui mataba el
+                # release completo en vez de degradar a ready=false.
+                echo "::notice::El artefacto publication-grade no paso la re-verificacion del release (exit $recheck_status); el paquete se publica sin adjuntar datos."
+                echo "ready=false" >> "$GITHUB_OUTPUT"
+              fi
               ;;
             2)
               echo "ready=false" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **855 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **856 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".
@@ -534,7 +534,7 @@ print(df.head())
 > **Versionado:** Para entornos productivos, fija la versión exacta en `requirements.txt`
 > (revisa el badge de PyPI al inicio de este README para la versión más reciente):
 > ```
-> chile-hub==1.22.0
+> chile-hub==1.23.0
 > ```
 > El bundle de datos se publica con cada release. La API del módulo `ChileHub` sigue
 > versionado semántico: cambios de interfaz pública solo en _major releases_.

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -289,6 +289,27 @@ class AdoptionBadgeGuardrailTests(unittest.TestCase):
         self.assertIn("uv sync --extra dev --extra pipeline", content)
         self.assertNotIn("uv sync --extra dev\n", content)
 
+    def test_release_degrades_to_ready_false_when_recheck_fails(self):
+        """La re-verificacion del artefacto no debe matar el release.
+
+        Regresion 2026-08-11 (run 31544671830): el release adopto el unico
+        artefacto publication-grade disponible, cuya provenance era de antes
+        de que el override se registrara (sin allow_stale_backfills), y la
+        re-verificacion rechazo ipc stale — el case abortaba el release
+        COMPLETO con exit 1. El diseno correcto (y el del propio workflow en
+        ready=false) es degradar: el paquete PyPI se publica igual, solo no se
+        adjuntan datos.
+        """
+        content = (ROOT_DIR / ".github" / "workflows" / "pypi-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('recheck_status="$?"', content)
+        self.assertIn('if [[ "$recheck_status" -eq 0 ]]', content)
+        self.assertIn("se publica sin adjuntar datos", content)
+        # La degradacion ocurre DENTRO del case 0 (tras la re-verificacion),
+        # no en el branch de error (*) que aborta.
+        self.assertIn('echo "ready=false" >> "$GITHUB_OUTPUT"', content)
+
     def test_hf_publish_uses_the_adopted_publication_grade_run(self):
         """hf-publish debe bajar el run que release efectivamente adopto.
 

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -303,8 +303,11 @@ class AdoptionBadgeGuardrailTests(unittest.TestCase):
         content = (ROOT_DIR / ".github" / "workflows" / "pypi-release.yml").read_text(
             encoding="utf-8"
         )
-        self.assertIn('recheck_status="$?"', content)
-        self.assertIn('if [[ "$recheck_status" -eq 0 ]]', content)
+        # `if` en vez de capturar $?: el step corre bajo set -e y un fallo de
+        # verify_pipeline mataria bash antes de asignar el exit code (P1 de la
+        # review del PR #57) — el ready=false nunca se emitiria.
+        self.assertIn("if python scripts/verify_pipeline.py --profile release", content)
+        self.assertNotIn('recheck_status="$?"', content)
         self.assertIn("se publica sin adjuntar datos", content)
         # La degradacion ocurre DENTRO del case 0 (tras la re-verificacion),
         # no en el branch de error (*) que aborta.


### PR DESCRIPTION
Regresion 2026-08-11 (run 31544671830): el release adopto el unico artefacto publication-grade disponible cuya provenance era de antes de que el override ADR-016 se registrara, la re-verificacion rechazo ipc stale y el case abortaba el release COMPLETO. Ahora degrada a ready=false: el paquete PyPI se publica igual, solo no se adjuntan datos. El release v1.23.0 ya se publico end-to-end (PyPI + GitHub Release con 5 assets de datos).