### PR TITLE
ci(docs): auto-heal del gate de sync en push a main (carrera con releases)

### DIFF
--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -37,6 +37,10 @@ jobs:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # contents: write solo se usa en el paso de auto-heal de docs, que está
+    # condicionado a push a main (nunca escribe en PRs ni en otras vías).
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -82,7 +86,34 @@ jobs:
         run: python scripts/check_companion_paths.py registry
 
       - name: Check docs sync (README hardcoded facts)
-        run: python scripts/sync_docs.py --check
+        run: |
+          if python scripts/sync_docs.py --check; then
+            exit 0
+          fi
+          # Drift de docs detectado. En push a main, la causa habitual es una
+          # carrera con un release: semantic-release pushea el bump de version
+          # entre la creacion de un PR y su merge, dejando el pin del README
+          # con la version anterior. El sync es determinista (regenera desde la
+          # fuente de verdad), asi que auto-corregirlo en main es estrictamente
+          # mejor que fallar: el pipeline actual sigue pasando y el siguiente
+          # push/schedule ya parte consistente. El commit usa GITHUB_TOKEN
+          # (que NO dispara workflows push — ver pages-deploy.yml), evitando
+          # un loop de pipelines.
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "::warning::Bloques de docs desincronizados en push a main (probable carrera con release); auto-corrigiendo..."
+            python scripts/sync_docs.py
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add README.md AGENTS.md
+            git commit -m "docs: auto-sync tras carrera con release [skip ci]" || echo "Sin cambios para commitear"
+            git push origin HEAD:main
+            echo "Auto-sync commiteado; el pipeline continua con el estado corregido."
+            exit 0
+          fi
+          # En PRs y demas vias el gate sigue siendo bloqueante: el autor debe
+          # traer el sync (nunca escribimos en la rama del autor).
+          echo "::error::Bloques de docs desincronizados. Corre 'make sync-docs' y commitea el resultado."
+          exit 1
 
       # Adelanta a cada push/PR la deriva que "Check build-synced files" solo
       # detecta en la vía schedule, tras un build completo (ver #270 con

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -37,10 +37,6 @@ jobs:
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # contents: write solo se usa en el paso de auto-heal de docs, que está
-    # condicionado a push a main (nunca escribe en PRs ni en otras vías).
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -86,34 +82,12 @@ jobs:
         run: python scripts/check_companion_paths.py registry
 
       - name: Check docs sync (README hardcoded facts)
-        run: |
-          if python scripts/sync_docs.py --check; then
-            exit 0
-          fi
-          # Drift de docs detectado. En push a main, la causa habitual es una
-          # carrera con un release: semantic-release pushea el bump de version
-          # entre la creacion de un PR y su merge, dejando el pin del README
-          # con la version anterior. El sync es determinista (regenera desde la
-          # fuente de verdad), asi que auto-corregirlo en main es estrictamente
-          # mejor que fallar: el pipeline actual sigue pasando y el siguiente
-          # push/schedule ya parte consistente. El commit usa GITHUB_TOKEN
-          # (que NO dispara workflows push — ver pages-deploy.yml), evitando
-          # un loop de pipelines.
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "::warning::Bloques de docs desincronizados en push a main (probable carrera con release); auto-corrigiendo..."
-            python scripts/sync_docs.py
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add README.md AGENTS.md
-            git commit -m "docs: auto-sync tras carrera con release [skip ci]" || echo "Sin cambios para commitear"
-            git push origin HEAD:main
-            echo "Auto-sync commiteado; el pipeline continua con el estado corregido."
-            exit 0
-          fi
-          # En PRs y demas vias el gate sigue siendo bloqueante: el autor debe
-          # traer el sync (nunca escribimos en la rama del autor).
-          echo "::error::Bloques de docs desincronizados. Corre 'make sync-docs' y commitea el resultado."
-          exit 1
+        # Gate read-only (job quality sin contents: write): el auto-heal vive
+        # en el job separado docs-autosync, que solo corre en push a main.
+        # Aqui el gate es bloqueante en todas las vias (incluido push a main:
+        # el job docs-autosync commitea el fix despues y el siguiente run ya
+        # parte consistente).
+        run: python scripts/sync_docs.py --check
 
       # Adelanta a cada push/PR la deriva que "Check build-synced files" solo
       # detecta en la vía schedule, tras un build completo (ver #270 con
@@ -137,6 +111,67 @@ jobs:
         run: |
           python scripts/check_companion_paths.py companions \
             --base "${{ github.event.pull_request.base.sha }}"
+
+  # Auto-heal de docs SOLO en push a main. Job separado con contents: write:
+  # el job quality se mantiene read-only, de modo que un PR de una rama del
+  # repo no puede ejecutar codigo controlado por el PR con un token de
+  # escritura (P1 de la review del PR #60). Este job corre el codigo de main
+  # (push ya aprobado), nunca el de una rama de PR.
+  docs-autosync:
+    name: Auto-sync docs (push a main)
+    # Corre incluso si quality falla: su proposito es arreglar el drift de docs
+    # que quality detecto (la causa habitual: carrera con un release). Si
+    # quality fallo por otra razon, el auto-sync no encontrara drift y no
+    # hara nada (el step valida con --check antes de tocar nada).
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: quality
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-suffix: docs-autosync
+
+      - name: Install dev dependencies
+        run: uv sync --extra pipeline --extra dev
+
+      - name: Auto-sync docs if stale
+        run: |
+          if python scripts/sync_docs.py --check; then
+            echo "Docs al dia; sin cambios."
+            exit 0
+          fi
+          # Drift de docs detectado en push a main. La causa habitual es una
+          # carrera con un release: semantic-release pushea el bump de version
+          # entre la creacion de un PR y su merge, dejando el pin del README
+          # con la version anterior. El sync es determinista (regenera desde la
+          # fuente de verdad), asi que auto-corregirlo es estrictamente mejor
+          # que dejar el gate rojo para un drift operativamente inevitable.
+          echo "::warning::Bloques de docs desincronizados en push a main (probable carrera con release); auto-corrigiendo..."
+          python scripts/sync_docs.py
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md AGENTS.md
+          git commit -m "docs: auto-sync tras carrera con release [skip ci]" || echo "Sin cambios para commitear"
+          # El commit usa GITHUB_TOKEN, que NO dispara workflows push (ver
+          # pages-deploy.yml) -> sin loop de pipelines. El siguiente push o
+          # schedule ya parte consistente.
+          git push origin HEAD:main
 
   build-and-test:
     name: Build and verify data

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **857 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **860 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/tests/test_chile_hub.py
+++ b/tests/test_chile_hub.py
@@ -1734,9 +1734,16 @@ class WorkflowContractTests(unittest.TestCase):
         )
 
     def test_pipeline_check_workflow_uses_split_bounded_jobs(self):
-        for job in ("quality:", "build-and-test:", "package-quality:", "landing:", "publish:"):
+        for job in (
+            "quality:",
+            "docs-autosync:",
+            "build-and-test:",
+            "package-quality:",
+            "landing:",
+            "publish:",
+        ):
             self.assertIn(job, self.workflow_text)
-        self.assertEqual(self.workflow_text.count("timeout-minutes:"), 5)
+        self.assertEqual(self.workflow_text.count("timeout-minutes:"), 6)
         self.assertIn("concurrency:", self.workflow_text)
 
     def test_pipeline_check_workflow_uses_one_generated_output_artifact(self):

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -490,6 +490,42 @@ class LandingSyncGateGuardrailTests(unittest.TestCase):
                 self.assertIn(f"class=\"pill ' + {var}", content)
 
 
+class DocsSyncGateGuardrailTests(unittest.TestCase):
+    """El gate de sync de docs debe auto-corregirse en push a main (carrera
+    con releases) pero seguir bloqueante en PRs.
+
+    Regresion 2026-08-12 (x2): semantic-release publico 1.23.1, 1.24.0 y
+    1.24.1 en menos de una hora; el release pushea el bump de version entre
+    la creacion de un PR y su merge, dejando el pin del README con la version
+    anterior. El CI del merge fallaba con "sync_readme_version_pin_example"
+    pese a que el PR no tenia regresion — un drift operativamente inevitable.
+    """
+
+    def test_quality_job_runs_docs_sync_gate(self):
+        content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("python scripts/sync_docs.py --check", content)
+
+    def test_docs_auto_heal_only_on_push_to_main(self):
+        """El auto-heal debe estar condicionado a push a main; nunca escribir
+        en la rama de un PR ni en otras vias (schedule/dispatch)."""
+        content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            'if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]',
+            content,
+        )
+        # El commit del bot usa GITHUB_TOKEN (no dispara workflows push -> sin loop).
+        self.assertIn("git push origin HEAD:main", content)
+        self.assertIn('git commit -m "docs: auto-sync tras carrera con release [skip ci]"', content)
+
+    def test_docs_gate_still_blocking_on_pr(self):
+        """En PRs el gate sigue exigiendo el sync del autor (exit 1)."""
+        content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "echo \"::error::Bloques de docs desincronizados. Corre 'make sync-docs'", content
+        )
+        self.assertIn("exit 1", content)
+
+
 class AgentsSyncGateGuardrailTests(unittest.TestCase):
     """AGENTS.md es prosa curada: sus hechos contables (anclas de líneas,
     listas de módulos del §2, tabla de capas del §1) no se regeneran con

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -505,25 +505,43 @@ class DocsSyncGateGuardrailTests(unittest.TestCase):
         content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("python scripts/sync_docs.py --check", content)
 
-    def test_docs_auto_heal_only_on_push_to_main(self):
-        """El auto-heal debe estar condicionado a push a main; nunca escribir
-        en la rama de un PR ni en otras vias (schedule/dispatch)."""
+    def test_docs_auto_heal_lives_in_separate_main_only_job(self):
+        """El auto-heal debe vivir en un job separado (docs-autosync),
+        condicionado a push a main, NUNCA en el job quality (que debe
+        permanecer read-only).
+
+        P1 de la review del PR #60: dar contents: write al job quality
+        permitiria que un PR de una rama del repo ejecute codigo controlado
+        por el PR con un token de escritura. El job separado corre el codigo
+        de main (push aprobado), nunca el de una rama de PR.
+        """
         content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
+        # El job separado existe y esta condicionado a push a main.
+        self.assertIn("  docs-autosync:", content)
+        self.assertIn("name: Auto-sync docs (push a main)", content)
         self.assertIn(
-            'if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]',
+            "if: github.event_name == 'push' && github.ref == 'refs/heads/main' && always()",
             content,
         )
         # El commit del bot usa GITHUB_TOKEN (no dispara workflows push -> sin loop).
         self.assertIn("git push origin HEAD:main", content)
         self.assertIn('git commit -m "docs: auto-sync tras carrera con release [skip ci]"', content)
+        # El gate del job quality es el check puro (read-only): el bloque entre
+        # el header del job quality y el comentario del job docs-autosync no
+        # debe contener un bloque de permissions propio.
+        quality_section = content.split("  quality:")[1].split("  # Auto-heal de docs")[0]
+        self.assertIn("python scripts/sync_docs.py --check", quality_section)
+        self.assertNotIn("permissions:", quality_section)
 
     def test_docs_gate_still_blocking_on_pr(self):
-        """En PRs el gate sigue exigiendo el sync del autor (exit 1)."""
+        """En PRs el gate sigue exigiendo el sync del autor (quality falla)."""
         content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("python scripts/sync_docs.py --check", content)
+        # El auto-heal nunca corre en PRs (job condicionado a push a main).
         self.assertIn(
-            "echo \"::error::Bloques de docs desincronizados. Corre 'make sync-docs'", content
+            "if: github.event_name == 'push' && github.ref == 'refs/heads/main' && always()",
+            content,
         )
-        self.assertIn("exit 1", content)
 
 
 class AgentsSyncGateGuardrailTests(unittest.TestCase):


### PR DESCRIPTION
## Problema

Regresión 2026-08-12 (x2): semantic-release publicó 1.23.1, 1.24.0 y 1.24.1 en menos de una hora. El release pushea el bump de versión **entre la creación de un PR y su merge**, dejando el pin del README con la versión anterior. El CI del merge fallaba el gate `sync_readme_version_pin_example` pese a que el PR **no tenía regresión** — un drift operativamente inevitable en esta arquitectura (releases en paralelo con merges).

## Solución: auto-heal del gate en push a main

El job quality ahora:
1. Corre `sync_docs.py --check` como siempre.
2. Si falla **y** el evento es `push` a `refs/heads/main`: corre `sync_docs.py` real, commitea con `[skip ci]` y pushea con `GITHUB_TOKEN`. El sync es determinista (regenera desde la fuente de verdad) — corregir es estrictamente mejor que fallar.
3. **Sin loop**: el commit del bot con GITHUB_TOKEN no dispara workflows `push` (mecanismo documentado en pages-deploy.yml).
4. El pipeline actual sigue pasando (el checkout ya está hecho); el siguiente push/schedule parte consistente.
5. **En PRs y demás vías el gate sigue bloqueante** (exit 1): el autor trae el sync; nunca escribimos en la rama del autor.

Permisos: job quality sube a `contents: write` solo para este paso, condicionado estrictamente a push a main.

## Verificación
- Validado end-to-end en clone real: pin stale **commiteado en HEAD** (el caso real del merge) → auto-sync lo corrige y commitea el diff.
- Guardrails nuevos: `DocsSyncGateGuardrailTests` (gate presente, auto-heal condicionado, gate bloqueante en PR).
- Suite 859 tests + 1 skip, lint, format, doctor verdes.