### PR TITLE
feat(ci): prepara el workflow para la merge queue (evento merge_group)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+    # Requerido porque CodeQL es un check requerido de la merge queue (la
+    # cola crea ramas temporales gh-readonly-queue/main/... y dispara
+    # merge_group); sin este trigger, el check requerido nunca se reporta y
+    # la cola espera para siempre.
   schedule:
     - cron: "30 11 * * 1"
   workflow_dispatch:

--- a/.github/workflows/pipeline-check.yml
+++ b/.github/workflows/pipeline-check.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
+    # Requerido por la merge queue (branch protection "Require merge queue"):
+    # la cola crea ramas temporales gh-readonly-queue/main/... y dispara el
+    # evento merge_group; sin este trigger los checks requeridos nunca se
+    # reportan y la cola falla todos los merges.
   schedule:
     # GitHub cron is UTC: 06:00 CLT or 07:00 CLST.
     - cron: "0 10 * * *"
@@ -29,6 +34,9 @@ env:
 
 concurrency:
   group: pipeline-${{ github.workflow }}-${{ github.ref }}
+  # En merge_group NO se cancela: la cola prueba varios PRs en paralelo en
+  # ramas temporales distintas (cada una con su propio ref/grupo), y cancelar
+  # los builds en curso romperia la formacion de grupos de la cola.
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **860 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **861 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **861 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **862 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/docs/release.md
+++ b/docs/release.md
@@ -106,3 +106,26 @@ narrativo escrito por un humano en `CHANGELOG.md`. El bloque usa el formato:
 - Los resúmenes narrativos van en **español neutral**, como el resto de la documentación
   del proyecto. Las categorías auto-generadas por PSR heredan el idioma de los mensajes
   de commit (inglés o español, según como se escribieron).
+
+## Merge queue (GitHub)
+
+Los PRs a `main` se mergean con merge queue: GitHub crea ramas temporales
+`gh-readonly-queue/main/...`, re-corre los checks requeridos contra el estado
+final (main + PR + PRs en cola) y mergea en FIFO solo si pasan. Esto elimina
+la carrera release-vs-merge (un release que pushea el bump de versión entre la
+creación del PR y su merge ya no deja el CI del merge con el pin viejo).
+
+**Cómo mergear un PR:** `gh pr merge <n> --auto --delete-branch` — agrega el PR
+a la cola; GitHub lo mergea cuando los checks requeridos pasan en el merge
+group. El PR debe tener los checks del pipeline verdes primero.
+
+**Configuración (UI, no hay API):** Settings → Branches → regla de `main` →
+"Require merge queue". Requiere que el workflow escuche el evento `merge_group`
+(ya configurado en `pipeline-check.yml` — sin ese trigger la cola fallaría
+todos los merges).
+
+**Limitaciones:** la cola espera a los checks requeridos (Python quality, Build
+and verify data, Landing smoke test, CodeQL) en el merge group; los jobs
+condicionados a `push` a main (p. ej. `docs-autosync`) no corren en la cola —
+correcto, la cola no debe escribir. Los commits de bot (`[skip ci]`) siguen
+pusheando directo a main sin pasar por la cola.

--- a/plans/069-ine-override-delivery-visible.md
+++ b/plans/069-ine-override-delivery-visible.md
@@ -1,0 +1,165 @@
+# Plan 069: Que el override INE sea un delivery visible (no enmascarado como backfill)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/extractors/bcentral_extractor.py src/validation.py scripts/verify_pipeline.py tests/test_extractors.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+El override INE (issue #43, serie IPC muerta en mindicador.cl) scrapea la
+variación mensual del IPC desde `ine.gob.cl`. El valor es **nuevo** (p. ej.
+2026-07-01 = 0.1), pero el build lo etiqueta como `published_backfill`
+("reutilización del último artefacto publicado", que es falso) porque el
+bucle de `published_backfills` corre **después** del bucle de
+`ine_override_pairs` y lo sobrescribe. El gate de publicación ADR-016
+(`verify_publication_policy`) —el único mecanismo pensado para frenar datos
+scrapeados sin revisión— queda inerte. Confirmado en `data/normalized/pipeline_metadata.json`
+del build publicado: `indicator_delivery.ipc == "published_backfill"` y
+`ine_override_pairs == ['ipc/2026']` simultáneamente.
+
+## Current state
+
+- `src/extractors/bcentral_extractor.py:459-463` — orden de los bucles que
+  construyen `indicator_delivery`:
+  ```python
+  for pair in diagnostics.get("ine_override_pairs", []):
+      indicator_delivery[pair.split("/", 1)[0]] = "ine_override"
+  for code in diagnostics.get("published_backfills", []):
+      indicator_delivery[code] = "published_backfill"
+  ```
+  El segundo sobrescribe al primero cuando co-ocurren (el caso real: el
+  extractor no pudo obtener ipc de mindicador y lo tomó del INE).
+- `scripts/verify_pipeline.py:541-547` — `verify_publication_policy` rechaza
+  deliveries fuera de un allowlist:
+  ```python
+  if dataset.get("source_mode") not in NON_FALLBACK_SOURCE_MODES:
+      violations.append(...)
+  ```
+  El delivery `ine_override` no está en el allowlist de `verify_dataset_catalog`
+  (`verify_pipeline.py:904-918`), así que si el enmascaramiento se quitara sin
+  tocar verify, el build fallaría — comportamiento deseado pero requiere el
+  allowlist con revisión explícita.
+- Tests: `tests/test_extractors.py:634-679`
+  (`test_process_indicators_records_ine_override_in_metadata`) cubre solo el
+  caso `load_existing_staging → (None, None, [])`; el caso co-ocurrente
+  (production) no está testeado y hoy contradice el test.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests focal | `./.venv/bin/pytest tests/test_extractors.py -q -k "IneIpc"` | all pass |
+| Build | `make build` | exit 0 |
+| Verify | `./.venv/bin/python scripts/verify_pipeline.py --profile publication` | exit 0 |
+| Lint | `make lint && make format-check` | exit 0 |
+| Doctor | `make doctor` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `src/extractors/bcentral_extractor.py`
+- `scripts/verify_pipeline.py`
+- `src/validation.py` (solo si se necesita una validación de delivery)
+- `tests/test_extractors.py`, `tests/test_pipeline_logic.py`, `tests/test_verify_pipeline.py`
+
+**Out of scope**:
+- `src/extractors/ine_ipc.py` (regex/fetch — plan separado)
+- Cambios en el gate de ADR-016 para otras series (UF/dólar/euro/UTM)
+- El bundle ZIP / catálogo (plan separado 071)
+
+## Git workflow
+
+- Branch: `advisor/069-ine-override-delivery`
+- Conventional commits, uno por paso lógico (ej. `fix(extractors): ...`).
+- No push ni PR salvo instrucción del operador.
+
+## Steps
+
+### Step 1: Reproduce el bug con un test que falle
+
+Agrega en `tests/test_extractors.py` (en `IneIpcOverrideIntegrationTests`) un
+test `test_override_coexists_with_published_backfill_delivery_visible` que
+simule el caso de producción: `load_existing_staging` devuelve
+`(existing, current_year, ["ipc"])` (el staging previo tiene ipc de 2025-12),
+`fetch_indicator_year("ipc", current_year)` devuelve `[]`, y
+`fetch_ine_ipc` devuelve el reading de julio. Luego `process_indicators()` y
+assert que `metadata["indicator_delivery"]["ipc"] == "ine_override"` y que
+`"ipc" not in metadata["published_backfills"]` o que el delivery gana.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py -q -k "override_coexists"` → FALLA (bug reproducido).
+
+### Step 2: Corrige el orden de los bucles
+
+En `src/extractors/bcentral_extractor.py:459-463`, aplica el bucle de
+`published_backfills` ANTES del de `ine_override_pairs` (o excluye los códigos
+de override del bucle de backfill), de modo que `ine_override` gane cuando
+ambos co-ocurran.
+
+**Verify**: el test del Step 1 pasa; `./.venv/bin/pytest tests/test_extractors.py -q -k "IneIpc"` → all pass.
+
+### Step 3: Registra `ine_override` en el allowlist de verify con revisión explícita
+
+En `scripts/verify_pipeline.py`, agrega `ine_override` a los deliveries
+permitidos por `verify_dataset_catalog` (líneas 904-918) SOLO cuando el
+override viene de una fuente autoritativa documentada (INE). Modela el
+patrón de `--allow-known-anomalies` (ADR-013) si se quiere revisión explícita;
+mínimo, el delivery debe ser visible en `pipeline_metadata.json`.
+
+**Verify**: `./.venv/bin/python scripts/verify_pipeline.py --profile publication` → exit 0 con el metadata real (que ahora dice `ine_override`).
+
+### Step 4: Actualiza el test existente y la doc
+
+Actualiza `test_process_indicators_records_ine_override_in_metadata` si
+necesita el caso co-ocurrente, y `docs/datasets/indicadores.md` para que el
+estado del delivery `ine_override` sea el documentado.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py tests/test_pipeline_logic.py tests/test_verify_pipeline.py -q` → all pass.
+
+## Test plan
+
+- `test_override_coexists_with_published_backfill_delivery_visible` (nuevo,
+  en `IneIpcOverrideIntegrationTests`) — el caso de producción.
+- Modelar sobre `test_process_indicators_records_ine_override_in_metadata`
+  existente.
+- Verificación: suite focal + `make build` + `verify --profile publication`.
+
+## Done criteria
+
+- [ ] `metadata["indicator_delivery"]["ipc"] == "ine_override"` en el build real
+- [ ] `verify_pipeline.py --profile publication` exit 0 con el metadata real
+- [ ] Test del caso co-ocurrente existe y pasa
+- [ ] `make lint && make format-check` exit 0
+- [ ] `make doctor` exit 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El código en las ubicaciones citadas no coincide con los excerpts (drift).
+- El metadata real ya dice `ine_override` sin el fix (el bug se corrigió por otra vía).
+- El gate de publicación empieza a rechazar el build diario por otra serie.
+
+## Maintenance notes
+
+- El delivery `ine_override` debe ser visible en `pipeline_metadata.json` —
+  es la provenance honesta que el Plan 066 construyó; no reintroducir el
+  enmascaramiento.
+- Revisar en el PR: que el allowlist de verify no acepte `ine_override` sin
+  la fuente autoritativa documentada.
+- Follow-up fuera de scope: hacer que `detect_series_anomalies` (Plan 072)
+  cubra el valor INE.

--- a/plans/070-hf-publication-track-filter.md
+++ b/plans/070-hf-publication-track-filter.md
@@ -1,0 +1,138 @@
+# Plan 070: Filtrar HF por publication_track (nunca candidate/deprecated)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- scripts/publish_hf_dataset.py docs/hf/ AGENTS.md tests/test_pipeline_logic.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none (pero coordina con 071 — ambos tocan el catálogo)
+- **Category**: bug / docs
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`AGENTS.md:750-753` afirma que el mirror de Hugging Face "nunca incluye el
+carril candidate". El script `publish_hf_dataset.py` selecciona por
+`outputs` truthy + `redistribution_ok is True` del catálogo, sin mirar
+`publication_track` del registry. **Confirmado en producción**: el mirror
+`cortega26/chile-hub` ya tiene 19 parquets, incluyendo
+`consumo_electrico_comunal.parquet` (fuente muerta, deprecated, 3 filas de
+muestra en fallback) y `perfil_territorial_comunal.parquet` (candidate).
+La política canónica se contradice sola: doc dice "nunca candidate", código
+sube candidate.
+
+## Current state
+
+- `scripts/publish_hf_dataset.py:40-63` — selección:
+  ```python
+  def select_publishable_files():
+      catalog = _read_catalog()
+      for name, entry in sorted(catalog.items()):
+          outputs = entry.get("outputs")
+          if not outputs:
+              continue
+          if entry.get("reuse_policy", {}).get("redistribution_ok") is not True:
+              continue
+  ```
+  El docstring (L44-45) asume "el carril candidate nunca declara outputs",
+  pero el build hoy declara `outputs` para las 2 candidate (verificado en
+  `data/normalized/dataset_catalog.json`).
+- `data/source_registry.json` — `publication_track: candidate` para
+  `perfil_territorial_comunal` (maturity: candidate) y
+  `consumo_electrico_comunal` (maturity: deprecated).
+- `AGENTS.md:750-753` — el claim "nunca incluye el carril candidate".
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Dry-run HF | `HF_TOKEN=x ./.venv/bin/python scripts/publish_hf_dataset.py --dry-run` | lista sin candidate |
+| Tests | `./.venv/bin/pytest tests/test_pipeline_logic.py -q` | all pass |
+| Doctor | `make doctor` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `scripts/publish_hf_dataset.py`
+- `tests/test_pipeline_logic.py` (guardrail de selección)
+- `AGENTS.md` (si el claim necesita matiz tras el fix)
+- `docs/hf/dataset-card.md` (si menciona el conteo)
+
+**Out of scope**:
+- El builder de catálogo (`src/builders/catalog.py`) — se toca en 071.
+- La landing (carril candidate visible) — DIR-01.
+- Re-verificación del mirror publicado (operador).
+
+## Git workflow
+
+- Branch: `advisor/070-hf-publication-track`
+- Conventional commits, uno por paso lógico.
+- No push ni PR salvo instrucción del operador.
+
+## Steps
+
+### Step 1: Lee el registry como fuente de carril
+
+En `select_publishable_files()`, carga `data/source_registry.json` (ya hay
+patrón de lectura en el repo, p. ej. `scripts/verify_pipeline.py`), construye
+el set de datasets con `publication_track == "stable_publishable"` (y NO
+`maturity_status == "deprecated"`), y filtra la selección por ese set **además**
+de `outputs` + `redistribution_ok`.
+
+**Verify**: `HF_TOKEN=x ./.venv/bin/python scripts/publish_hf_dataset.py --dry-run` → la lista NO contiene `consumo_electrico_comunal` ni `perfil_territorial_comunal`; sigue teniendo 17 parquets.
+
+### Step 2: Guardrail de selección
+
+En `tests/test_pipeline_logic.py` (modelar sobre `AdoptionStatsTests` o el
+patrón de `select_publishable_files` existente), test que `select_publishable_files()`
+NO incluye candidate/deprecated del registry, y que falla ruidoso si una
+`stable_publishable` carece de su Parquet.
+
+**Verify**: `./.venv/bin/pytest tests/test_pipeline_logic.py -q -k "hf\|publishable"` → all pass.
+
+### Step 3: Actualiza la doc
+
+Confirma que `AGENTS.md:750-753` y `docs/hf/dataset-card.md` reflejen el
+comportamiento real (17 capas, candidate excluido por `publication_track`).
+
+**Verify**: `make sync-docs` sin cambios inesperados; `make doctor` exit 0.
+
+## Test plan
+
+- `test_hf_excludes_candidate_and_deprecated` (nuevo) — lee el registry real
+  y verifica que la selección no contiene candidate/deprecated.
+- Modelar sobre el test existente de `select_publishable_files` (si existe)
+  o sobre `AdoptionStatsTests`.
+- Verificación: suite focal + dry-run.
+
+## Done criteria
+
+- [ ] `--dry-run` lista 17 capas, sin candidate/deprecated
+- [ ] Test de selección existe y pasa
+- [ ] `make doctor` exit 0
+- [ ] `AGENTS.md` y la doc de HF coherentes con el código
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El registry no tiene `publication_track` para algún dataset (drift de schema).
+- El dry-run excluye más de lo esperado (un stable_publishable sin `outputs`).
+
+## Maintenance notes
+
+- El script HF y el builder de catálogo comparten la noción de "publicable";
+  el fix de 071 (catálogo del ZIP) debe re-verificar este script para no
+  romper la consistencia.
+- El mirror publicado ya contiene las 2 candidate — re-verificar
+  `cortega26/chile-hub` tras el fix es tarea del operador (subida real).

--- a/plans/071-bundle-catalog-consistency.md
+++ b/plans/071-bundle-catalog-consistency.md
@@ -1,0 +1,143 @@
+# Plan 071: El catálogo del bundle ZIP solo declara capas realmente incluidas
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/builders/artifacts.py src/builders/catalog.py scripts/verify_pipeline.py tests/test_pipeline_logic.py tests/test_builders_artifacts.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: coordina con 070 (ambos tocan "qué es publicable")
+- **Category**: bug
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+El ZIP publicable contiene 16 parquet pero su `dataset_catalog.json` interno
+declara 19 capas con `outputs` — 3 sin archivo (`comunas_enriquecidas` alias
+de `comunas`, `perfil_territorial_comunal` y `consumo_electrico_comunal`,
+ambas candidate). Un consumidor que itere el catálogo del bundle (o use
+`from_datapackage`/data manager) encuentra capas que no existen. El drift
+viaja en cada release publicado. Confirmado leyendo el ZIP real
+(`data/normalized/chile-hub-publishable-bundle.zip`).
+
+## Current state
+
+- `src/builders/artifacts.py:28-55` — el índice del bundle filtra por
+  `public_bundle_eligible`:
+  ```python
+  eligible = {entry["dataset"] for entry in registry if entry.get("public_bundle_eligible")}
+  ```
+- `src/builders/artifacts.py:86+` — el `dataset_catalog.json` entra como
+  shared artifact completo, sin filtrar.
+- `src/builders/catalog.py` — produce `dataset_catalog.json` con todas las
+  capas con `outputs` (incluidas candidate).
+- Verificación del ZIP (existe un test de conteo de entradas,
+  `artifacts.py:400-403` / `test_builders_artifacts.py`), pero no compara
+  catálogo vs contenido.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `make build` | exit 0 |
+| Verificar ZIP | `./.venv/bin/python -c "..."` (ver Step 2) | catálogo == contenido |
+| Tests | `./.venv/bin/pytest tests/test_builders_artifacts.py tests/test_pipeline_logic.py -q` | all pass |
+| Doctor | `make doctor` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `src/builders/artifacts.py` (o `src/builders/catalog.py` — decide en Step 1)
+- `tests/test_builders_artifacts.py`
+- `tests/test_chile_hub.py` (contrato del bundle si aplica)
+
+**Out of scope**:
+- El mirror HF (070).
+- La landing (DIR-01).
+- Cambiar `public_bundle_eligible` del registry.
+
+## Git workflow
+
+- Branch: `advisor/071-bundle-catalog-consistency`
+- Conventional commits, uno por paso lógico.
+- No push ni PR salvo instrucción del operador.
+
+## Steps
+
+### Step 1: Decide el punto de filtrado
+
+Analiza si el filtro debe ir en `catalog.py` (el catálogo construido no
+declara `outputs` para candidate — más limpio, pero toca la landing que
+también lee el catálogo) o en `artifacts.py` (generar una variante del
+catálogo para el ZIP, filtrada por `public_bundle_eligible` — menor impacto).
+Recomendación: variante en `artifacts.py` (el catálogo principal queda
+intacto para landing/API).
+
+**Verify**: decisión documentada en el commit; `make build` exit 0.
+
+### Step 2: Implementa el filtrado + test de consistencia
+
+Genera el `dataset_catalog.json` del ZIP filtrado por `public_bundle_eligible`
+(excepto el alias `comunas_enriquecidas` → `comunas`, que debe quedar con su
+`outputs` apuntando al parquet real). Agrega en `tests/test_builders_artifacts.py`
+un test que compare, tras `make build`, cada entrada con `outputs` del
+catálogo interno del ZIP contra `zipfile.namelist()` — no debe haber entradas
+sin su parquet.
+
+**Verify**: `./.venv/bin/pytest tests/test_builders_artifacts.py -q` → all pass.
+
+### Step 3: Verifica el bundle resultante
+
+```bash
+./.venv/bin/python - <<'PY'
+import zipfile, json
+z = zipfile.ZipFile("data/normalized/chile-hub-publishable-bundle.zip")
+names = set(z.namelist())
+cat = json.loads(z.read("data/normalized/dataset_catalog.json"))
+missing = [d["dataset"] for d in cat["datasets"] if d.get("outputs")
+           and f"data/normalized/{d['dataset']}.parquet" not in names
+           and d["dataset"] != "comunas_enriquecidas"]
+assert not missing, missing
+print("catálogo del ZIP consistente:", len(cat["datasets"]), "entradas")
+PY
+```
+**Verify**: sin missing; el ZIP sigue teniendo 16 parquet (17 con el alias).
+
+## Test plan
+
+- `test_bundle_catalog_matches_zip_contents` (nuevo) — el assert del Step 3
+  como test parametrizado sobre el bundle real.
+- Modelar sobre los tests existentes de `test_builders_artifacts.py`.
+- Verificación: suite focal + `make build`.
+
+## Done criteria
+
+- [ ] El catálogo interno del ZIP no declara capas sin su parquet
+- [ ] El alias `comunas_enriquecidas` sigue funcionando (apunta al parquet real)
+- [ ] Test de consistencia existe y pasa
+- [ ] `make doctor` exit 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- La landing o `hub_bundle.json` dependen del catálogo sin filtrar de forma
+  que el filtro las rompa (verificar `app.js`).
+- El test de consistencia falla por una capa legítima que debería estar
+  (drift en `public_bundle_eligible`).
+
+## Maintenance notes
+
+- Al agregar un dataset nuevo, el contrato "catálogo del ZIP == contenido"
+  queda protegido por el test — no relajar el test para acomodar drift.
+- Coordinar con 070: el script HF lee el mismo catálogo; si 070 filtra por
+  registry y 071 filtra el ZIP, ambos deben producir el mismo conjunto.

--- a/plans/072-zip-slip-guard.md
+++ b/plans/072-zip-slip-guard.md
@@ -1,0 +1,124 @@
+# Plan 072: Validar miembros del ZIP antes de extractall (zip-slip/symlink)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/chile_hub/data_manager.py tests/test_data_manager.py tests/test_chile_hub.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: security
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`_extract_bundle` hace `archive.extractall()` sobre el ZIP descargado sin
+inspeccionar `namelist()`. El checksum SHA-256 verifica el bundle contra un
+`.sha256` de la **misma** release de GitHub — no añade un dominio de
+confianza distinto. Si la release se viera comprometida (supply chain), un
+miembro con `../` o un symlink permitiría escritura arbitraria fuera del
+directorio de caché en la máquina de cada consumidor que corre
+`chile-hub cache update`. Es el clásico zip-slip, atenuado solo por la
+confianza en el mantenedor.
+
+## Current state
+
+- `src/chile_hub/data_manager.py:371-375`:
+  ```python
+  def _extract_bundle(self, bundle_path: Path) -> None:
+      if self.normalized_dir.exists():
+          shutil.rmtree(self.normalized_dir)
+      with zipfile.ZipFile(bundle_path) as archive:
+          archive.extractall(self.version_cache_dir)
+  ```
+- El bundle legítimo (`chile-hub-publishable-bundle.zip`) tiene 56 entradas,
+  todas bajo `data/normalized/` — el allowlist no rompería nada actual.
+- El patrón de errores del módulo es `ChileHubDataError` (ver `clear()` en
+  `data_manager.py:199-207`).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests | `./.venv/bin/pytest tests/test_data_manager.py tests/test_chile_hub.py -q` | all pass |
+| Lint | `make lint && make format-check` | exit 0 |
+
+## Scope
+
+**In scope**:
+- `src/chile_hub/data_manager.py` (`_extract_bundle`)
+- `tests/test_data_manager.py`
+
+**Out of scope**:
+- El descargador (`update()`/checksum) — ya es robusto.
+- Otros consumers de ZIP en el repo.
+
+## Git workflow
+
+- Branch: `advisor/072-zip-slip-guard`
+- Conventional commits, uno por paso lógico.
+- No push ni PR salvo instrucción del operador.
+
+## Steps
+
+### Step 1: Valida los miembros antes de extraer
+
+En `_extract_bundle`, antes de `extractall`, itera `archive.infolist()` y
+rechaza (con `ChileHubDataError` y el nombre del miembro en el mensaje):
+- `member.filename` que no empiece por `data/normalized/`
+- `member.filename` con `..` o `\` (path traversal)
+- `member.is_symlink()` o `member.is_dir()` con path absoluto (`/` inicial)
+- `member.filename` vacío o `.`
+
+Extrae miembro a miembro con `arcname` sanitizado, o mantén `extractall`
+solo tras validar toda la lista (equivalente si el allowlist es estricto).
+
+**Verify**: `./.venv/bin/pytest tests/test_data_manager.py -q` → all pass.
+
+### Step 2: Tests de regresión
+
+En `tests/test_data_manager.py` (modelar sobre `GeoCacheIntegrityTests` /
+`ChileHubDataManagerUnitTests`), agrega:
+- `test_extract_rejects_zip_slip_member` — ZIP sintético con miembro
+  `../evil.txt`; assert `ChileHubDataError` y que el archivo NO se creó.
+- `test_extract_rejects_symlink_member` — ZIP con symlink; assert error.
+- `test_extract_accepts_legitimate_bundle` — ZIP con entradas bajo
+  `data/normalized/`; assert extracción ok (reusa el patrón del bundle
+  sintético existente en `ChileHubDataManagerUnitTests`).
+
+**Verify**: `./.venv/bin/pytest tests/test_data_manager.py -q -k "extract"` → all pass.
+
+## Test plan
+
+- 3 tests nuevos en `tests/test_data_manager.py` (los del Step 2).
+- Modelar sobre `ChileHubDataManagerUnitTests::test_extract_bundle_cleans_existing_normalized_dir`.
+- Verificación: suite focal + suite completa.
+
+## Done criteria
+
+- [ ] `_extract_bundle` rechaza miembros fuera de `data/normalized/`
+- [ ] 3 tests nuevos pasan
+- [ ] El bundle legítimo se extrae sin cambios
+- [ ] `make lint && make format-check` exit 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- Algún bundle legítimo del pasado tiene entradas fuera de `data/normalized/`
+  (el allowlist rompería `cache update` para cachés existentes — investigar
+  antes de continuar).
+
+## Maintenance notes
+
+- Si en el futuro el bundle incluye `contracts/` (Plan 074), ampliar el
+  allowlist a ese prefijo — el test de bundle legítimo lo detectará.

--- a/plans/073-contracts-for-consumers.md
+++ b/plans/073-contracts-for-consumers.md
@@ -1,0 +1,142 @@
+# Plan 073: Contratos disponibles para consumidores instalados (wheel + bundle)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/chile_hub/core.py src/chile_hub/contracts.py pyproject.toml src/builders/artifacts.py tests/test_chile_hub.py tests/test_packaging_runtime.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: bug / dx
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`ChileHub.validate_dataset()` / `validate_user_data()` / CLI `validate`
+resuelven los contratos en `self.root_dir / "contracts" / "datasets"`, donde
+`root_dir` deriva del directorio de datos descargado (`core.py:668,711`).
+El wheel (`packages = ["src/chile_hub"]`) y el bundle ZIP (56 entradas) **no
+contienen `contracts/`** — un consumidor instalado (PyPI) que corra
+`chile-hub validate mi_archivo.csv --dataset comunas` falla con
+`ChileHubDatasetError: No existe contrato de schema`. La validación de datos
+de usuario — la función que existe para que consumidores cotejen sus CSVs —
+es inalcanzable sin clonar el repo.
+
+## Current state
+
+- `src/chile_hub/core.py:668` (`validate_dataset`) y `:711`
+  (`validate_user_data`):
+  ```python
+  contract_path = self.root_dir / "contracts" / "datasets" / f"{dataset_name}.schema.json"
+  ```
+- `pyproject.toml:122-129` — `[tool.hatch.build.targets.wheel] packages = ["src/chile_hub"]`
+  (no incluye `contracts/`).
+- `src/builders/artifacts.py` — el ZIP publicable no incluye `contracts/`.
+- `scripts/check_companion_paths.py` — el registry valida que cada dataset
+  tenga contrato en `contracts/datasets/`, pero no valida que viaje.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build wheel | `python -m build --wheel --outdir /tmp/opencode/dist` | success |
+| Instalar | `pip install /tmp/opencode/dist/*.whl` (venv limpio) | success |
+| Smoke instalado | `chile-hub validate <csv> --dataset comunas` (venv limpio) | status ok |
+| Tests | `./.venv/bin/pytest tests/test_chile_hub.py tests/test_packaging_runtime.py -q` | all pass |
+
+## Scope
+
+**In scope**:
+- `pyproject.toml` (wheel: incluir `contracts/datasets/`)
+- `src/chile_hub/core.py` (resolución con fallback a `importlib.resources`)
+- `src/builders/artifacts.py` (bundle: incluir contratos — decidir en Step 1)
+- `scripts/check_companion_paths.py` (si el registry debe validar el empaquetado)
+- `tests/test_packaging_runtime.py`, `tests/test_chile_hub.py`
+
+**Out of scope**:
+- El CLI `validate` en sí (ya funciona si el contrato existe).
+- Los contratos en runtime del pipeline (`scripts/verify_pipeline.py`).
+
+## Git workflow
+
+- Branch: `advisor/073-contracts-for-consumers`
+- Conventional commits, uno por paso lógico.
+- No push ni PR salvo instrucción del operador.
+
+## Steps
+
+### Step 1: Decide el alcance (wheel, bundle, o ambos)
+
+Analiza `test_packaging_runtime.py` (qué cubre hoy) y decide: mínimo viable es
+el **wheel** (la vía PyPI — el caso reportado). El bundle es deseable pero
+toca `check_companion_paths.py` y el manifiesto. Recomendación: wheel primero;
+bundle como Step opcional si el mantenimiento lo permite.
+
+**Verify**: decisión documentada en el commit.
+
+### Step 2: Empaqueta los contratos en el wheel
+
+En `pyproject.toml`, agrega los contratos al wheel (p. ej.
+`[tool.hatch.build.targets.wheel] packages = ["src/chile_hub"]` +
+`force-include` de `contracts/datasets/*.schema.json` dentro del paquete como
+`src/chile_hub/contracts/datasets/`, o via `include`). Verifica el contenido
+del wheel con `unzip -l`.
+
+**Verify**: `python -m build --wheel` → el wheel contiene `*.schema.json`.
+
+### Step 3: Resolución con fallback
+
+En `core.py`, resuelve el contrato así:
+1. `self.root_dir / "contracts" / "datasets"` (checkout / bundle con contratos)
+2. fallback: `importlib.resources.files("chile_hub") / "contracts" / "datasets"`
+   (wheel instalado)
+
+Extrae la resolución a un helper (p. ej. `_contract_path(dataset_name)`) usado
+por `validate_dataset`, `validate_user_data` y el CLI `validate`.
+
+**Verify**: en un venv limpio con el wheel, `chile-hub validate <csv> --dataset comunas` → `status: ok`.
+
+### Step 4: Tests
+
+En `tests/test_packaging_runtime.py` (o `test_chile_hub.py`), test que con
+`root_dir` sin contratos la resolución cae al fallback del paquete; y que el
+wheel incluye los schemas.
+
+**Verify**: `./.venv/bin/pytest tests/test_packaging_runtime.py tests/test_chile_hub.py -q` → all pass.
+
+## Test plan
+
+- Test de fallback: `root_dir` vacío → contrato resuelto desde el paquete.
+- Test de wheel: `unzip -l` del wheel contiene schemas.
+- Modelar sobre los tests existentes de `test_packaging_runtime.py`.
+
+## Done criteria
+
+- [ ] El wheel contiene `contracts/datasets/*.schema.json`
+- [ ] `chile-hub validate <csv> --dataset comunas` funciona en venv limpio
+- [ ] Test de fallback existe y pasa
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- `importlib.resources` no puede acceder a archivos del wheel (problema de
+  empaquetado — verificar con `unzip -l` primero).
+- El fallback rompe la resolución en checkout (orden incorrecto de los paths).
+
+## Maintenance notes
+
+- Al agregar un dataset, `check_companion_paths.py` valida el contrato en el
+  repo; este plan no cambia eso — el empaquetado es un paso adicional.
+- Revisar en el PR: que `self.root_dir` siga siendo la primera opción (el
+  bundle descargado debe poder sobreescribir los contratos del paquete).

--- a/plans/074-anomalies-last-point-attribution.md
+++ b/plans/074-anomalies-last-point-attribution.md
@@ -1,0 +1,93 @@
+# Plan 074: Anomalías temporales sobre el punto más reciente (IPC negativo)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/validation.py tests/test_validation.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`detect_series_anomalies` construye log-retornos saltando pares donde
+`prev_value <= 0 or curr_value <= 0`, pero `last_return = log_returns[-1]`
+es el último par **admitido**, no necesariamente el más reciente; luego
+`prev_value = values[-2]` y `dates[-1]` sí son los últimos. Para el IPC
+mensual chileno los valores negativos son frecuentes (el propio staging tiene
+`2025-12-01 = -0.2`): cuando el mes más reciente es negativo, la señal se
+calcula sobre un par viejo pero se reporta con la fecha y el rango del mes
+nuevo — la anomalía queda mal atribuida. Es justamente el guard del valor
+scrapeado del INE (Plan 069), que queda debilitado.
+
+## Current state
+
+- `src/validation.py:356-380` — construcción de log-retornos con filtro
+  `prev_value <= 0 or curr_value <= 0` y `last_return = log_returns[-1]`.
+- Tests: `tests/test_validation.py` — casos de `detect_series_anomalies`
+  (ruido estable, serie corta, tendencia gradual) del Plan 054.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests focal | `./.venv/bin/pytest tests/test_validation.py -q -k "anomal"` | all pass |
+| Lint | `make lint && make format-check` | exit 0 |
+
+## Scope
+
+**In scope**: `src/validation.py`, `tests/test_validation.py`
+**Out of scope**: el override INE (069), el umbral `z_threshold` (calibrado).
+
+## Steps
+
+### Step 1: Corrige la atribución del último punto
+
+En `detect_series_anomalies`, evalúa explícitamente el **último punto
+cronológico**: si el par más reciente no entró en los log-retornos (por valor
+≤ 0), usa un detector de nivel alternativo (p. ej. z-score sobre los últimos
+N valores, o comparación del último cambio absoluto contra la desviación
+histórica) en vez de reportar con fecha del último punto un par viejo.
+Asegura que `dates`/`esperado_rango` correspondan al punto evaluado.
+
+**Verify**: test nuevo con serie terminando en valor negativo (p. ej.
+`[0.3, 0.5, -0.2]`) reporta la anomalía —si la hay— con la fecha correcta.
+
+### Step 2: Tests de regresión
+
+En `tests/test_validation.py`, agrega:
+- `test_anomaly_last_point_negative_value` — serie con último valor negativo;
+  la anomalía (si la hay) se atribuye a la fecha correcta.
+- `test_anomaly_negative_values_no_crash` — serie con varios negativos; no
+  crashea y no reporta falsos positivos.
+
+**Verify**: `./.venv/bin/pytest tests/test_validation.py -q -k "anomal"` → all pass.
+
+## Done criteria
+
+- [ ] El último punto negativo se evalúa con la fecha correcta
+- [ ] 2 tests nuevos pasan
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El detector de nivel alternativo cambia el set de anomalías reportadas en
+  los 506 registros reales de calibración (verificar contra el fixture).
+
+## Maintenance notes
+
+- Si el umbral cambia en el futuro, re-calibrar con el fixture de 506
+  registros reales (patrón del Plan 054).

--- a/plans/075-ine-regex-value-period-coupling.md
+++ b/plans/075-ine-regex-value-period-coupling.md
@@ -1,0 +1,102 @@
+# Plan 075: Acoplar valor y período en el regex del override INE
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/extractors/ine_ipc.py tests/test_extractors.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW-MED
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+El regex del override INE ancla el `<h1>` del IPC y captura el primer
+`<p class="cifraV3">…%` siguiente con `[\s\S]*?` hasta el
+`periodoCifraV3` con "Variación mensual". Si el INE reordena el layout y pone
+otra tarjeta (variación anual, acumulada, de otro índice) entre el h1 del IPC
+y su cifra mensual, el valor capturado puede ser el de otra tarjeta mientras
+el período es el del IPC — un valor erróneo entra silenciosamente al dataset
+y al bundle. El único freno (anomalías, Plan 074) está debilitado.
+
+## Current state
+
+- `src/extractors/ine_ipc.py:46-52` — `_PATTERN`:
+  ```python
+  _PATTERN = re.compile(
+      rf"<h1[^>]*>[^<]*[ÍI]ndice\s+de\s+Precios\s+al\s+Consumidor[^<]*</h1>"
+      rf"[\s\S]*?<p[^>]*class=\"[^\"]*\bcifraV3\b[^\"]*\"[^>]*>\s*(-?\d+(?:[,.]\d+)?)\s*%\s*</p>"
+      rf"[\s\S]*?<p[^>]*class=\"[^\"]*\bperiodoCifraV3\b[^\"]*\"[^>]*>\s*Variaci[oó]n\s+mensual\s+"
+      rf"({_MONTH_PATTERN})\s+(\d{{4}})",
+      re.IGNORECASE,
+  )
+  ```
+- Fixture real: `tests/fixtures/ine_ipc_page.html` (julio 2026, 0.1%).
+- Tests: `tests/test_extractors.py:424-499` (`IneIpcExtractorTests`),
+  incluido `test_parse_anchors_to_ipc_card_not_sibling_card`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests focal | `./.venv/bin/pytest tests/test_extractors.py -q -k "IneIpc"` | all pass |
+| Lint | `make lint && make format-check` | exit 0 |
+
+## Scope
+
+**In scope**: `src/extractors/ine_ipc.py`, `tests/test_extractors.py`
+**Out of scope**: el fetch (`fetch_ine_ipc`), la cadena multi-fuente (DIR-04).
+
+## Steps
+
+### Step 1: Restringe el span entre cifra y período
+
+Reemplaza el `[\s\S]*?` entre `cifraV3` y `periodoCifraV3` por un span
+acotado (p. ej. `[^<]{0,200}`) que impida saltar a otra tarjeta: el par debe
+estar en el mismo bloque contenedor. Alternativa más robusta: parsear la
+tarjeta completa (desde el h1 hasta el cierre de su contenedor) y extraer
+cifra+período dentro de ese subárbol.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py -q -k "IneIpc"` → all pass (fixture real sigue parseando 0.1%).
+
+### Step 2: Tests adversariales con tarjetas reordenadas
+
+En `tests/test_extractors.py` (`IneIpcExtractorTests`), agrega:
+- `test_parse_rejects_mismatched_sibling_card` — HTML con h1 del IPC, luego
+  la cifra de OTRA tarjeta, y luego el período mensual del IPC → el parser
+  debe devolver el valor del IPC o `None`, nunca el valor ajeno.
+- `test_parse_sibling_card_between_h1_and_value` — tarjeta hermana (ICT)
+  intercalada entre el h1 y la cifra del IPC → sin falsos positivos.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py -q -k "IneIpc"` → all pass (nuevos incluidos).
+
+## Done criteria
+
+- [ ] El regex no puede casar valor de una tarjeta con período de otra
+- [ ] 2 tests adversariales pasan
+- [ ] El fixture real sigue parseando 0.1% jul-2026
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El span acotado rompe el parseo del fixture real (el layout actual tiene
+  más de 200 chars entre cifra y período — medir antes).
+
+## Maintenance notes
+
+- Si el INE cambia el layout, este test adversarial es la primera alerta —
+  no "arreglar" el test, revisar el patrón.
+- La fragilidad estructural (publish diario depende de HTML externo) se
+  documenta en DIR-04 (ADR multi-fuente).

--- a/plans/076-res-incremental-fetch.md
+++ b/plans/076-res-incremental-fetch.md
@@ -1,0 +1,104 @@
+# Plan 076: RES incremental — descargar solo el año en curso
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/extractors/res_extractor.py tests/test_extractors.py .github/workflows/pipeline-check.yml`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: perf
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`res_extractor.py` re-descarga y re-parsea el histórico completo (2013→actual,
+~14 archivos, consolidado 228 MB / ~1.57M filas) **cada día**, incluso con
+cache-hit de CI (el workflow lo corre siempre en schedule). El dato que
+cambia es solo el año en curso. bcentral ya tiene el patrón incremental
+(descarga solo el año en curso cuando existe staging); RES no — cada corrida
+diaria gasta ~2-5 min del job (timeout 30 min) y ~200-350 MB de tráfico.
+
+## Current state
+
+- `src/extractors/res_extractor.py:134-141` — descarga todos los CSVs
+  anuales; `:156-185` re-parsea todo con `df.unique()` y `sort` sobre ~1.57M
+  filas.
+- `bcentral_extractor.py:241-246` — el patrón incremental a replicar:
+  `years_to_fetch = [current_year] if existing_df is not None else range(HISTORY_START_YEAR, current_year+1)`.
+- `src/extractors/res_extractor.py` — la dedup `unique(keep="last")` protege
+  contra solapamiento entre archivos anuales (salvaguarda a conservar).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests focal | `./.venv/bin/pytest tests/test_extractors.py -q -k "Res"` | all pass |
+| Lint | `make lint && make format-check` | exit 0 |
+
+## Scope
+
+**In scope**: `src/extractors/res_extractor.py`, `tests/test_extractors.py`
+**Out of scope**: el workflow (no cambia la cadencia), el formato del
+consolidado (contrato intacto).
+
+## Steps
+
+### Step 1: Detecta el rango ya presente
+
+Replica el patrón de `load_existing_staging` de bcentral: si
+`data/staging/empresas.csv` existe, deriva el rango de años presentes (o
+guarda el rango en `empresas.metadata.json`); si no, descarga el histórico
+completo. Descarga solo `current_year` (+1 año de solapamiento si el archivo
+anual del año anterior se publica con retraso).
+
+**Verify**: test con staging sintético (años 2013-2025) → el fetch solo pide el año actual.
+
+### Step 2: Merge incremental conservando la dedup
+
+Concatena el staging previo con el nuevo año y aplica
+`unique(subset=..., keep="last")` — la misma dedup de hoy, ahora solo sobre
+el merge, no sobre la re-descarga completa. Preserva el `sort` final.
+
+**Verify**: con staging sintético de años previos + fetch del año actual, el
+resultado tiene las filas previas + las nuevas, sin duplicados.
+
+### Step 3: Tests de regresión
+
+En `tests/test_extractors.py` (clase `ResExtractorTests`), agrega:
+- `test_incremental_only_fetches_current_year` — staging previo presente.
+- `test_incremental_preserves_history` — filas de años previos intactas.
+- `test_incremental_dedup_overlap` — solapamiento anual deduplicado.
+- `test_full_fetch_when_no_staging` — sin staging, descarga completa.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py -q -k "Res"` → all pass.
+
+## Done criteria
+
+- [ ] Con staging previo, solo se descarga el año en curso
+- [ ] Historial previo preservado y deduplicado
+- [ ] 4 tests nuevos pasan
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El merge incremental pierde filas de años previos (comparar contra el
+  consolidado actual antes del cambio).
+- La fuente cambia el formato de los archivos anuales (drift).
+
+## Maintenance notes
+
+- Si la fuente publica el año anterior con retraso (revisar), el +1 de
+  solapamiento lo cubre — documentar el hallazgo en el código.
+- El ahorro diario esperado: ~2-5 min del job de CI y ~250 MB de tráfico.

--- a/plans/077-characterize-build-dev-db.md
+++ b/plans/077-characterize-build-dev-db.md
@@ -1,0 +1,115 @@
+# Plan 077: Caracterizar build_dev_db.py (cobertura 21% → ≥60%)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/build_dev_db.py tests/test_pipeline_logic.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: L
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: tests
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`build_dev_db.py` (883 líneas, 59 commits de churn desde 2026-05) tiene 21%
+de cobertura: todo `main()` y las fases
+`_load_inputs`/`_compute_validations`/`_write_data_artifacts`/`_generate_reports`
+están sin test (missing 227-514, 519-656, 661-765, 775-831). El corazón del
+pipeline —la feature por la que existe el repo— puede romperse en la ruta
+feliz sin que la suite lo detecte; cualquier refactor de `main()` es a ciegas.
+
+## Current state
+
+- `src/build_dev_db.py` — `main()` + 4 fases; los únicos paths cubiertos son
+  los de error temprano (`tests/test_pipeline_logic.py:87-124`).
+- Patrón a reutilizar: `tests/test_verify_pipeline.py:88-121` (staging
+  sintético en tmpdir + parcheo de rutas); `tests/geo_fixtures.py`
+  (fixtures sintéticos).
+- `pyproject.toml:182-185` — TC-02 documentado como follow-up pendiente.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Cobertura | `./.venv/bin/pytest tests/test_pipeline_logic.py --cov=src.build_dev_db --cov-report=term-missing` | ≥60% tras el plan |
+| Tests | `./.venv/bin/pytest tests/test_pipeline_logic.py -q` | all pass |
+
+## Scope
+
+**In scope**: `tests/test_pipeline_logic.py` (o archivo nuevo
+`tests/test_build_dev_db.py` — decidir según tamaño), fixtures sintéticos.
+**Out of scope**: refactor de `build_dev_db.py` (solo lectura), los
+extractores, los builders (planes separados).
+
+## Steps
+
+### Step 1: Baseline de cobertura
+
+Mide la cobertura actual por fase y documenta el baseline en el commit.
+
+**Verify**: `--cov=src.build_dev_db` reporta ~21%.
+
+### Step 2: Staging sintético mínimo
+
+Construye un helper (en el archivo de test) que cree en un tmpdir: los
+CSVs + metadata.json necesarios para `_load_inputs` (patrón de
+`test_verify_pipeline.py`), parcheando `STAGING_DIR`/`NORMALIZED_DIR`/rutas
+de `build_dev_db`.
+
+**Verify**: el helper crea el staging y `_load_inputs` lo lee sin red ni
+extractores (assert de la estructura cargada).
+
+### Step 3: Caracteriza las fases puras primero
+
+Cubre `_compute_validations` (pura — dados los inputs, assert del dict de
+validaciones y el resultado de los validadores registrados). Luego
+`_write_data_artifacts` (assert de artefactos de salida en tmpdir).
+
+**Verify**: cobertura de las 2 fases > 60% individual.
+
+### Step 4: Caracteriza `main()` y `_generate_reports`
+
+Con el staging sintético, corre `main()` completo (sin ZIP si se puede
+parchear, o con ZIP en tmpdir) y asserta los reportes de salida
+(`hub_health.json`, `pipeline_status.md`, etc.).
+
+**Verify**: cobertura de `build_dev_db` ≥ 60% en total.
+
+## Test plan
+
+- Tests de caracterización por fase; modelar sobre
+  `tests/test_verify_pipeline.py::VerifySyntheticTests`.
+- Assertar invariantes (existencia + estructura), no contenido exacto.
+- Verificación: `--cov=src.build_dev_db` ≥ 60%; suite completa verde.
+
+## Done criteria
+
+- [ ] Cobertura de `build_dev_db.py` ≥ 60% (era 21%)
+- [ ] Tests de las 4 fases + `main()` existen
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- La caracterización congela un bug real (validar contra el artefacto golden
+  publicado antes de escribir asserts).
+- `main()` requiere red o extractores para correr (diseñar el staging para
+  que no — si es imposible, cubrir las fases por separado y reportar).
+
+## Maintenance notes
+
+- Estos tests son la red de seguridad para el TECHDEBT-02 heredado y para
+  cualquier refactor futuro de `build_dev_db.py`.
+- El patrón de staging sintético puede reutilizarse en TEST-COV-09
+  (reports.py).

--- a/plans/078-parallelize-cead-geometria.md
+++ b/plans/078-parallelize-cead-geometria.md
@@ -1,0 +1,107 @@
+# Plan 078: Paralelizar CEAD y geometría (scrapes secuenciales)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/extractors/cead_delincuencia_live_extractor.py src/extractors/geometria_comunal_extractor.py tests/test_extractors.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: none
+- **Category**: perf
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+Dos scrapes secuenciales con riesgo de timeout:
+1. **CEAD** (`cead_delincuencia_live_extractor.py:388-404`): 346 POSTs
+   secuenciales, uno por comuna, con rate-limit `sleep(max(elapsed*2, 0.5))`
+   y `timeout=120` por request; el job `scrape-cead` tiene `timeout-minutes:
+   45` (`monthly-scrape.yml:106`). Con degradación (~6-7s por comuna) el job
+   muere y el mes queda sin dato.
+2. **Geometría** (`geometria_comunal_extractor.py:166-192`): fallback
+   por-comuna secuencial (timeout 90 por request) bajo `timeout-minutes: 20`
+   del workflow bajo demanda.
+
+El repo ya tiene precedente: `autoridades_locales_extractor.py:506-529`
+(`ThreadPoolExecutor`). No hay dependencia entre comunas en ninguno.
+
+## Current state
+
+- `cead_delincuencia_live_extractor.py:388-404` — loop secuencial con
+  `_fetch_comuna_data` (`:236-241`) y sleeps de rate-limit.
+- `geometria_comunal_extractor.py:166-192` — `_fetch_region_comuna_codes` +
+  un request por comuna (`_fetch_comuna`, `:129-144`).
+- Precedente: `autoridades_locales_extractor.py:506-529`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests focal | `./.venv/bin/pytest tests/test_extractors.py -q -k "Cead\|Geometria"` | all pass |
+| Lint | `make lint && make format-check` | exit 0 |
+
+## Scope
+
+**In scope**: ambos extractores + tests.
+**Out of scope**: el rate-limit del endpoint (respetarlo), el formato de
+salida (contrato intacto), el workflow.
+
+## Steps
+
+### Step 1: CEAD con workers acotados
+
+Extrae el cuerpo del loop a una función por comuna y despacha con
+`ThreadPoolExecutor(max_workers=4)`, acumulando el sleep de cortesía global
+entre tandas (preservando el rate-limit agregado, no por comuna). Mantén
+`continue-on-error` y el conteo de fallos.
+
+**Verify**: test con `_fetch_comuna_data` mockeado → los 346 se invocan con
+≤4 concurrentes; el tiempo total se reduce.
+
+### Step 2: Geometría con workers acotados
+
+Mismo patrón en el fallback por-comuna (`ThreadPoolExecutor(max_workers=4)`),
+manteniendo el registro de fallos por comuna en las notas.
+
+**Verify**: test con fetch mockeado → el fallback despacha en paralelo.
+
+### Step 3: Tests
+
+En `tests/test_extractors.py`, agrega tests que verifiquen el despacho
+paralelo (workers ≤ N concurrentes, todos los códigos procesados, fallos
+registrados). Modelar sobre los tests de `autoridades_locales_extractor`.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py -q -k "Cead\|Geometria"` → all pass.
+
+## Done criteria
+
+- [ ] CEAD despacha ≤4 workers concurrentes
+- [ ] Geometría (fallback) despacha ≤4 workers
+- [ ] Rate-limit agregado preservado
+- [ ] Tests nuevos pasan
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El endpoint rechaza con 403/429 el paralelismo moderado (probar con 2
+  workers si 4 falla — el rate-limit es deliberado).
+- El orden de escritura del consolidado cambia (si algún consumidor depende
+  del orden de comunas).
+
+## Maintenance notes
+
+- Si CEAD sigue siendo lento con 4 workers, subir a 6 tras validación —
+  documentar la decisión en el código.
+- El riesgo de timeout del job mensual queda mitigado pero no eliminado;
+  monitorizar la duración real en el próximo `monthly-scrape`.

--- a/plans/079-cover-geo-cead-reports.md
+++ b/plans/079-cover-geo-cead-reports.md
@@ -1,0 +1,107 @@
+# Plan 079: Cobertura de writers y extractores sin test (geo, CEAD, reports)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/builders/geo.py src/builders/reports.py src/extractors/cead_delincuencia_live_extractor.py tests/test_extractors.py tests/test_pipeline_logic.py tests/geo_fixtures.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW
+- **Depends on**: none (077 cubre build_dev_db; este cubre los módulos)
+- **Category**: tests
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+Tres módulos críticos sin cobertura:
+1. **`src/builders/geo.py` 0%** — el writer del GeoParquet (ADR-012) no tiene
+   ningún test; un bug en `simplify(preserve_topology=True)` o en el footer
+   geo pasaría directo al workflow manual.
+2. **`src/extractors/cead_delincuencia_live_extractor.py` 0%** — el único
+   extractor sin tests; si el portal CEAD cambia el HTML/shape, falla
+   silenciosamente y se descubre solo en la revisión mensual manual.
+3. **`src/builders/reports.py` 35%** — los reportes que alimentan
+   README/landing/health (badges, `hub_health.json`) sin cubrir; esta zona ya
+   rompió publish dos veces (drift real).
+
+## Current state
+
+- `src/builders/geo.py` — `write_geometria_comunal_parquet` (WKB, schema
+  1.0.0); `tests/geo_fixtures.py:63-67` ya tiene `write_synthetic_parquet`
+  con el mismo encoding.
+- `cead_delincuencia_live_extractor.py` — 209 stmts, 0 cubiertos; corre en
+  `monthly-scrape.yml:103-130` con "Revisar manualmente" si falla.
+- `src/builders/reports.py` — missing 300-345, 532-594, 617-755, 874-888,
+  903-1045 (build_hub_health, pipeline_status, freshness, quality).
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Cobertura | `./.venv/bin/pytest tests/test_extractors.py tests/test_pipeline_logic.py --cov=src.builders.geo --cov=src.builders.reports --cov=src.extractors.cead_delincuencia_live_extractor --cov-report=term-missing` | ≥60% en los 3 |
+| Tests | `./.venv/bin/pytest tests/test_extractors.py tests/test_pipeline_logic.py -q` | all pass |
+
+## Scope
+
+**In scope**: tests (nuevos archivos o extensiones), fixtures sintéticos.
+**Out of scope**: el código de los 3 módulos (solo lectura salvo bugs
+encontrados por los tests — reportar, no arreglar en este plan).
+
+## Steps
+
+### Step 1: Writer GeoParquet (geo.py)
+
+Test round-trip: `write_geometria_comunal_parquet` con el schema de staging
+(WKT) → `gpd.read_parquet` → assert CRS EPSG:4326, columnas esperadas,
+`simplify_tolerance=0` preserva todos los polígonos. Reusa
+`tests/geo_fixtures.py`.
+
+**Verify**: cobertura de `src.builders.geo.py` ≥ 60%; test pasa.
+
+### Step 2: CEAD
+
+Guarda un snapshot real del portal CEAD como fixture (o construye HTML/JSON
+sintético si el portal no es accesible), testea parse + normalización +
+metadata. Al menos los helpers puros. Modelar sobre `IneIpcExtractorTests`
+(`test_extractors.py:424-499`).
+
+**Verify**: cobertura de CEAD ≥ 60%; tests pasan.
+
+### Step 3: reports.py
+
+Con el staging sintético del Plan 077 (o un builder mínimo), ejercita
+`build_hub_health`/`build_pipeline_status`/`build_freshness` y asserta
+invariantes (dataset_count, drifted/warn/retired, severidad) — no texto
+exacto. Modelar sobre `HubHealthHistoryTests` (`test_pipeline_logic.py:2537`).
+
+**Verify**: cobertura de `src.builders.reports.py` ≥ 60%; tests pasan.
+
+## Done criteria
+
+- [ ] geo.py ≥ 60% de cobertura
+- [ ] CEAD ≥ 60% de cobertura
+- [ ] reports.py ≥ 60% de cobertura
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El fixture CEAD real no puede obtenerse (portal caído) — usar HTML
+  sintético fiel al shape documentado y anotarlo.
+- Un test encuentra un bug real en el writer/reportes — reportar con el
+  repro, no arreglar en este plan (plan separado).
+
+## Maintenance notes
+
+- Si CEAD cambia el layout, el test del fixture es la primera alerta.
+- reports.py quedará cubierto con el staging sintético compartido del 077 —
+  mantener ese helper en un archivo común.

--- a/plans/080-test-hygiene-batch.md
+++ b/plans/080-test-hygiene-batch.md
@@ -1,0 +1,125 @@
+# Plan 080: Higiene de tests (red real, sleeps inefectivos, staleness, e2e)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- tests/test_core.py tests/test_chile_hub.py tests/test_extractors.py tests/test_validation.py tests/e2e/run_all.sh tests/e2e/verify_066.sh src/extractors/http_utils.py pyproject.toml Makefile`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M
+- **Risk**: LOW-MED
+- **Depends on**: none
+- **Category**: tests / dx
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+Cinco fricciones de tests medidas:
+1. **~20s (29% de la suite) dependen de red real**: `check_sources` ×2
+   (`test_core.py:366-373`, `test_chile_hub.py:1614-1618`) y el fetch live a
+   BCN SIIT (`test_extractors.py:2356-2367`). El test de alcaldes falla si
+   BCN está vivo pero entrega <340 filas.
+2. **3 `@patch("tenacity.nap.sleep")` inefectivos** (`test_extractors.py:
+   1557,1576,1598`): tenacity 9.1.4 captura `sleep` en import-time; los tests
+   duermen 8s reales con el patch "activo".
+3. **Staleness guard inconsistente**: `_assert_normalized_not_stale`
+   (`test_chile_hub.py:68-101`) se llama solo en 3 de 9 clases; `test_core.py`
+   (73 tests) y `ChileHubCliTests` pasan contra artefactos stale.
+4. **`test_equivalencia_con_rutificador` skip permanente**
+   (`test_validation.py:999`): `rutificador` no está en el venv.
+5. **`tests/e2e/run_all.sh` no incluye `verify_066.sh`** (y los verify_NNN
+   con aserciones de datos vivos se rompen con el tiempo).
+6. **Makefile**: `verify` ≡ `verify-dev`, `verify-live` obsoleto, help de
+   `test` engañoso.
+7. **pytest-xdist declarado y nunca usado**.
+
+## Current state
+
+- Ver Current state de cada finding en el Why (evidencia con líneas).
+- `src/extractors/http_utils.py:34-65` — `fetch_with_retry` usa
+  `@retry(wait=wait_exponential(min=2, max=8))` con `sleep` default capturado.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Tests focal | `./.venv/bin/pytest tests/test_core.py tests/test_extractors.py tests/test_validation.py -q` | all pass |
+| Timing | `time ./.venv/bin/pytest -q` | < 60s tras el plan |
+| Doctor | `make doctor` | exit 0 |
+
+## Scope
+
+**In scope**: los archivos listados en el drift check.
+**Out of scope**: re-diseño de fixtures grandes; cambiar el contrato de
+`check_sources` (solo mocks en tests).
+
+## Steps
+
+### Step 1: Mockear red en check_sources y alcaldes
+
+Parchea `requests.head` con respuestas fake en los 2 tests de `check_sources`
+(consolidando en uno si son redundantes); convierte el test de alcaldes a
+fixture HTML/JSON sintético con N filas (el parseo se testea sin red). La
+señal de liveness ya la cubre `source-urls.yml` (semanal).
+
+**Verify**: `time ./.venv/bin/pytest tests/test_core.py tests/test_extractors.py -q` → baja ~20s.
+
+### Step 2: Fix de los sleeps de tenacity
+
+Añade parámetro `sleep` a `fetch_with_retry` y pásalo al `@retry` (tenacity
+lo acepta como kwarg), o en los tests construye el `Retrying` manualmente con
+`sleep=mock`. Verifica que `mock.call_count > 0` en un test.
+
+**Verify**: `./.venv/bin/pytest tests/test_extractors.py -q -k "retry\|timeout"` → all pass, sin sleeps reales (medir).
+
+### Step 3: Staleness guard en todas las clases
+
+Llama `_assert_normalized_not_stale` en `setUpClass` de `test_core.py` y
+`ChileHubCliTests` (moverlo a un helper compartido si es necesario).
+
+**Verify**: suite completa verde con `make build` previo.
+
+### Step 4: rutificador + e2e + Makefile
+
+- `test_equivalencia_con_rutificador`: añade `rutificador` al extra `dev` o
+  reemplaza el oráculo por una implementación DV inline (10 líneas).
+- `run_all.sh`: añade `066` al array o congela los scripts en
+  `plans/archive/` (decisión documentada — las aserciones de datos vivos se
+  rompen con el tiempo).
+- Makefile: elimina `verify-dev` o `verify`, elimina `verify-live`, corrige
+  el help de `test`; prueba `pytest -n auto` y si pasa fíjalo en Makefile/CI
+  (si no, elimina la dependencia xdist).
+
+**Verify**: `make doctor` exit 0; suite completa verde; `time make test` < 60s.
+
+## Done criteria
+
+- [ ] Suite sin red real (los 3 tests mockeados)
+- [ ] 8s de sleeps inefectivos eliminados
+- [ ] Staleness guard en todas las clases con `data/normalized/`
+- [ ] `test_equivalencia_con_rutificador` corre (no skip)
+- [ ] `run_all.sh` coherente (066 incluido o scripts congelados)
+- [ ] Makefile sin targets muertos/duplicados
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- `pytest -n auto` rompe fixtures compartidos (revertir a serial y eliminar
+  la dependencia — documentar).
+- El fixture de alcaldes no puede construirse sin la respuesta real
+  (el parseo depende de shape no documentado).
+
+## Maintenance notes
+
+- Los tests con red eran la única señal de liveness en la suite; la
+  cobertura queda en `source-urls.yml` — mantenerlo como el gate semanal.
+- La decisión e2e (incluir 066 vs congelar) debe documentarse en el commit
+  con el razonamiento.

--- a/plans/081-docs-quickstart-lanes-inventory.md
+++ b/plans/081-docs-quickstart-lanes-inventory.md
@@ -1,0 +1,113 @@
+# Plan 081: Docs — quickstart R, marcas de carril, inventario de extractores
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- docs/r-quickstart.md AGENTS.md docs/extraction-lanes.md src/builders/doc_sync.py scripts/check_agents_sync.py docs/datasets/perfil_territorial_comunal.md`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: docs
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+Tres inconsistencias de documentación con impacto real:
+1. **`docs/r-quickstart.md` roto**: la Opción A (recomendada) hace
+   `read_parquet("chile-hub-data/comunas.parquet")` pero los arcnames del ZIP
+   llevan prefijo `data/normalized/`; la Opción C abre
+   `chile-hub-data/chile_data.duckdb` que **no existe en el bundle** (no viaja
+   .duckdb/.db/.xlsx). Un usuario R siguiendo la doc no puede consumir el
+   producto.
+2. **AGENTS.md §1 no marca 2 candidate**: `perfil_territorial_comunal` y
+   `consumo_electrico_comunal` (este último deprecated) no llevan la marca
+   `carril candidate` que sí tienen geometría/delincuencia/autoridades
+   locales; la tabla canónica contradice al registry que cita.
+3. **`ine_ipc.py` invisible**: AGENTS.md dice "19 extractores" (hay 20) y
+   `extraction-lanes.md` omite el override INE del carril diario; el gate
+   anti-drift (`doc_sync.py:305` cuenta solo `*_extractor.py`) no lo detecta.
+
+## Current state
+
+- `docs/r-quickstart.md:15-16,47` — rutas inexistentes (verificado contra el
+  ZIP real: arcnames `data/normalized/...`, sin .duckdb).
+- `AGENTS.md:57,68,69` — marcas candidate presentes; `:62,65` ausentes.
+- `src/builders/doc_sync.py:305` — cuenta `*_extractor.py`;
+  `EXTRACTOR_DESCRIPTIONS` (`:249-292`) sin `ine_ipc`.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Sync check | `make sync-docs` | exit 0 |
+| Doctor | `make doctor` | exit 0 |
+| Verificar ZIP | `unzip -l data/normalized/chile-hub-publishable-bundle.zip` | ver rutas |
+
+## Scope
+
+**In scope**: los archivos del drift check.
+**Out of scope**: decidir si el .duckdb debe viajar en el bundle (decisión de
+producto — si se decide que sí, es otro plan; este plan documenta el estado
+real).
+
+## Steps
+
+### Step 1: Corrige r-quickstart.md
+
+Actualiza la Opción A a `chile-hub-data/data/normalized/comunas.parquet`.
+Para la Opción C, reemplaza el ejemplo de `.duckdb` por consulta duckdb sobre
+los parquet individuales (como ya hace el resto de la doc), o documenta
+explícitamente que el .duckdb no viaja en el bundle (según la decisión de
+producto).
+
+**Verify**: `grep -n "data/normalized" docs/r-quickstart.md` → rutas reales;
+`unzip -l` confirma que existen.
+
+### Step 2: Marcas de carril en AGENTS.md
+
+Añade "(carril `candidate`)" a las filas de perfil y consumo (y "deprecated"
+a consumo), coherente con el registry. Añade el header "Carril:" al doc
+`docs/datasets/perfil_territorial_comunal.md` (sus hermanas candidate lo
+tienen).
+
+**Verify**: `make doctor` exit 0 (check_agents_sync no rompe — si lo hace,
+ampliar `check_layers_table` para verificar marcas contra el registry).
+
+### Step 3: Inventario de extractores
+
+En `doc_sync.py`, incluye `ine_ipc.py` en el conteo/inventario (o deriva el
+conteo de `src/extractors/*.py` menos los 4 compartidos). Agrega una línea en
+`docs/extraction-lanes.md` sobre el override INE en el carril diario.
+
+**Verify**: `make sync-docs` regenera el árbol con 20 extractores; `make doctor` exit 0.
+
+## Done criteria
+
+- [ ] r-quickstart.md usa rutas reales del ZIP
+- [ ] AGENTS.md marca las 5 candidate (incluida consumo como deprecated)
+- [ ] El inventario de extractores cuenta `ine_ipc.py` (20)
+- [ ] `make doctor` exit 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El `check_agents_sync` no puede verificar las marcas sin romper otros
+  hechos — documentar y ajustar el check con cuidado.
+- La decisión de producto sobre el .duckdb en el bundle no está tomada —
+  documentar el estado real y dejar la decisión anotada.
+
+## Maintenance notes
+
+- El punto ciego del gate (módulos que no siguen la convención de nombre)
+  queda cubierto al incluir `ine_ipc` explícitamente — si se agregan más
+  módulos sin sufijo `_extractor`, ampliar la derivación.

--- a/plans/082-landing-candidate-lane.md
+++ b/plans/082-landing-candidate-lane.md
@@ -1,0 +1,99 @@
+# Plan 082: Mostrar el carril candidate en la landing
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- index.html app.js src/builders/reports.py src/builders/landing.py tests/test_chile_hub.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M
+- **Risk**: MED
+- **Depends on**: 070, 071 (que el catálogo distinga carriles limpiamente)
+- **Category**: direction
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`hub_bundle.json` produce `candidate_datasets` con `maturity_status` y
+`next_action` que ninguna UI consume; `app.js:844` renderiza solo las 17
+estables. `perfil_territorial_comunal` — capa derivada con cobertura 346/346,
+`validation_status: ok`, 9 datasets consolidados (la promesa literal de "una
+línea de código") — es invisible en la superficie principal. El sistema de
+carriles (un diferenciador real del producto) queda sin expresión visual y
+los analistas no pueden evaluar datos candidate.
+
+## Current state
+
+- `app.js:844` — renderiza `bundle.datasets` (17 estables).
+- `src/builders/reports.py` — produce `candidate_datasets` en el bundle.
+- `index.html` — hero/Capacidades no mencionan el concepto de carril.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `make build` | exit 0 |
+| Landing verify | `make verify-landing` | exit 0 |
+| Tests | `./.venv/bin/pytest tests/test_chile_hub.py -q` | all pass |
+
+## Scope
+
+**In scope**: `index.html`, `app.js`, tests de landing.
+**Out of scope**: la decisión de promover candidate (DIR-03), el conteo
+público "17 capas" en el hero (no cambiar sin decisión de producto).
+
+## Steps
+
+### Step 1: Render de la sección candidate
+
+En `app.js`, renderiza una sección "En evaluación (candidate)" después del
+catálogo estable, leyendo `bundle.candidate_datasets`, con badge explícito
+"candidate" + `maturity_status` + `next_action`. Sin contar en el total del
+catálogo estable.
+
+**Verify**: con el bundle real, la sección candidate aparece con perfil y
+consumo; el catálogo estable sigue mostrando 17.
+
+### Step 2: Estilos + verificación
+
+Agrega estilos coherentes con la paleta existente (`.candidate-*`). Asegura
+que `make verify-landing` siga pasando (los textos verificados del catálogo
+estable intactos).
+
+**Verify**: `make verify-landing` exit 0; Playwright muestra la sección.
+
+### Step 3: Tests de guardrail
+
+En `tests/test_ci_config.py` (o el patrón de landing guardrails), test que
+`app.js` renderiza `candidate_datasets` y que el catálogo estable no se
+contamina.
+
+**Verify**: suite focal verde.
+
+## Done criteria
+
+- [ ] Sección candidate visible con badge y `next_action`
+- [ ] Catálogo estable intacto (17, textos verificados)
+- [ ] `make verify-landing` exit 0
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- La landing rompe `verify_landing.py` (textos byte-checked) — verificar con
+  el smoke test real antes de tocar selectores existentes.
+- El hero "17 capas" cambia de sentido sin decisión de producto.
+
+## Maintenance notes
+
+- Esta sección hace visible el sistema de carriles — el copy debe ser
+  honesto: "evaluados, no en el bundle público" (AGENTS.md §1).
+- Coordinar con DIR-03: si perfil se promueve, sale de esta sección.

--- a/plans/083-review-approaching-signal.md
+++ b/plans/083-review-approaching-signal.md
@@ -1,0 +1,98 @@
+# Plan 083: Señal proactiva de review_by inminente (cadencia gestionada)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- src/builders/reports.py scripts/verify_pipeline.py tests/test_pipeline_logic.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: S-M
+- **Risk**: LOW
+- **Depends on**: none
+- **Category**: direction
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+Cuatro `review_by` vencen en 5-10 semanas (hoy 2026-08-12):
+`perfil_territorial_comunal` 2026-09-18, `delincuencia_comunal` 2026-09-21,
+`autoridades_locales` 2026-10-05, `geometria_comunal` 2026-10-21. El sistema
+solo marca "⚠ ESTANCADO (revisión vencida)" cuando la fecha ya pasó
+(`reports.py:548-561`) — no hay señal de aproximación. Un estado
+`review_approaching` (< 30 días) en `source_readiness.json`/reporte de salud
+convierte el sistema de carriles documentado en una cadencia gestionada en
+vez de deuda silenciosa.
+
+## Current state
+
+- `data/source_registry.json` — 4 fechas `review_by` inminentes.
+- `src/builders/reports.py:548-561` — solo marca vencidas, no próximas.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `make build` | exit 0 |
+| Tests | `./.venv/bin/pytest tests/test_pipeline_logic.py -q` | all pass |
+
+## Scope
+
+**In scope**: `src/builders/reports.py`, `scripts/verify_pipeline.py` (si el
+gate lo consume), tests.
+**Out of scope**: las decisiones de carril por dataset (juicio del
+mantenedor) — la señal solo las agenda.
+
+## Steps
+
+### Step 1: Estado review_approaching
+
+En el builder de readiness/salud, computa `days_until_review_by` y emite
+`review_status: upcoming` (< 30 días), `due` (< 0), `ok` (else) — sin tocar
+el enum de severidad existente (agregar campo, no ampliar enums).
+
+**Verify**: test con registry sintético (fechas a 10/40 días) → estado
+correcto.
+
+### Step 2: Superficie en el reporte de salud
+
+Expón `review_approaching_count` en `hub_health.json` y el detalle por
+dataset en `source_readiness.md`. Sin cambiar el `overall_status`.
+
+**Verify**: `make build` → `hub_health.json` tiene el campo nuevo con el
+conteo real (4 hoy).
+
+### Step 3: Tests + gates
+
+Agrega gate `review_approaching_count` entero `>= 0` en `verify_pipeline.py`
+(si hay patrón de gates para hub_health) y tests.
+
+**Verify**: suite focal verde; `make doctor` exit 0.
+
+## Done criteria
+
+- [ ] `review_status` por dataset en readiness (upcoming/due/ok)
+- [ ] `review_approaching_count` en hub_health.json
+- [ ] Tests nuevos pasan
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- Un cambio en `overall_status` altera el badge de la landing (no debe —
+  el campo es aditivo).
+- El registry no tiene `review_by` para algún candidate (drift de schema).
+
+## Maintenance notes
+
+- Esta señal agenda las 4 decisiones de carril; el mantenedor decide cada
+  una (promover/deprecar), no el código.
+- Cuando venzan, la señal pasa a `due` y el estado "ESTANCADO" existente
+  sigue funcionando como hoy.

--- a/plans/084-promote-perfil-territorial.md
+++ b/plans/084-promote-perfil-territorial.md
@@ -1,0 +1,102 @@
+# Plan 084: Promover perfil_territorial_comunal al bundle estable
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- data/source_registry.json data/dataset_catalog_config.json docs/datasets/perfil_territorial_comunal.md contracts/datasets/perfil_territorial_comunal.schema.json src/build_dev_db.py tests/test_chile_hub.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3 (decisión de producto del mantenedor)
+- **Effort**: S-M
+- **Risk**: MED
+- **Depends on**: 070/071 (coherencia del catálogo al promover)
+- **Category**: direction
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+`perfil_territorial_comunal` es la capa derivada que consolida 9 datasets por
+`codigo_comuna` — "Chile en una tabla", la promesa literal de AGENTS.md §1.
+Hoy es candidate invisible (cobertura 346/346, `validation_status: ok` en el
+catálogo), con `review_by 2026-09-18` que fuerza la decisión pronto. El
+mecanismo de derivación (`build_dev_db.py:495-536`) hace barato mantenerla.
+Promoverla ataca la adopción — la señal que §10 exige antes de agregar
+datasets — sin agregar fuentes nuevas.
+
+## Current state
+
+- `data/source_registry.json` — `perfil_territorial_comunal`:
+  `publication_track: candidate`, `review_by: 2026-09-18`.
+- `src/build_dev_db.py:465,637` — construye y valida la capa (346/346, ok).
+- `docs/datasets/perfil_territorial_comunal.md` — documenta el uso como tabla
+  única; no tiene header "Carril:" (ver Plan 081).
+- `freshness_policy: derivada` — ya presente (mitiga el riesgo de bugs de
+  agregación como datos "oficiales").
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Build | `make build` | exit 0 |
+| Tests | `./.venv/bin/pytest tests/test_chile_hub.py tests/test_pipeline_logic.py -q` | all pass |
+| Doctor | `make doctor` | exit 0 |
+
+## Scope
+
+**In scope**: `data/source_registry.json`, `data/dataset_catalog_config.json`
+(si el catálogo distingue carriles), docs, tests de contrato.
+**Out of scope**: agregar datasets nuevos; promover otras candidate.
+
+## Steps
+
+### Step 1: Flip de carril
+
+Cambia `publication_track` a `stable_publishable` en el registry y verifica
+que el build lo incluye en el bundle (parquet en el ZIP, catálogo consistente
+— el Plan 071 debe estar antes o coordinarse).
+
+**Verify**: `make build` → `perfil_territorial_comunal.parquet` en el bundle;
+`verify_pipeline.py --profile publication` exit 0.
+
+### Step 2: Docs y contrato
+
+Actualiza `docs/datasets/perfil_territorial_comunal.md` (header Carril:
+stable, nota de derivación), el badge de capas (17→18) y cualquier test que
+fije el conteo (`EXPECTED_DATASET_COUNT` o similar).
+
+**Verify**: `make sync-docs` regenera los bloques; suite verde.
+
+### Step 3: Contrato de artefactos
+
+Actualiza `ArtifactContractTests` y `EXPECTED_DATASET_COUNT` si existen; el
+nuevo parquet debe pasar todos los contratos (ya validado en el build hoy).
+
+**Verify**: `./.venv/bin/pytest tests/test_chile_hub.py -q` → all pass.
+
+## Done criteria
+
+- [ ] `perfil_territorial_comunal` en el bundle estable (18 capas)
+- [ ] Parquet en el ZIP y catálogo consistente
+- [ ] Docs y conteos actualizados
+- [ ] Suite completa verde
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El build rechaza la capa al promover (algún gate espera candidate).
+- El conteo público "17 capas" del hero/landing requiere decisión de copy
+  (el plan no cambia el hero sin instrucción).
+
+## Maintenance notes
+
+- Decisión de producto: el mantenedor la ratifica (es la que agenda el
+  review_by 2026-09-18 de todos modos).
+- Si se promueve, la sección candidate de la landing (Plan 082) pierde una
+  entrada — coordinar.

--- a/plans/085-adr-multi-source-ipc-override.md
+++ b/plans/085-adr-multi-source-ipc-override.md
@@ -1,0 +1,104 @@
+# Plan 085: ADR multi-fuente para el override de IPC (estrategia revisable)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md`.
+>
+> **Drift check (run first)**: `git diff --stat 53781e2..HEAD -- docs/adr/ docs/extraction-lanes.md src/extractors/ine_ipc.py src/extractors/bcentral_extractor.py`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M
+- **Risk**: LOW
+- **Depends on**: 069 (delivery visible), 075 (regex robusto)
+- **Category**: direction
+- **Planned at**: commit `53781e2`, 2026-08-12
+
+## Why this matters
+
+El publish diario de `indicadores` depende de un parseo HTML anclado al
+`<h1>` y clases CSS de `ine.gob.cl` (`ine_ipc.py`). La doc del dataset
+promete "una estrategia histórica más clara para IPC y UTM frente a snapshots
+parciales del agregador" (`docs/datasets/indicadores.md:128`) — no entregada.
+AGENTS.md §10 prohíbe scraping HTML frágil como fuente principal; el override
+es la excepción de último recurso, validado en producción, pero sin ADR
+propio: la cadena multi-fuente (INE HTML → series IPC → backfill) y su escape
+hatch no están decididos ni documentados. Un rediseño de `ine.gob.cl` rompe
+silenciosamente el carril diario.
+
+## Current state
+
+- `src/extractors/ine_ipc.py:1-13` — docstring con la justificación y el
+  patrón validado (citando el proyecto Monedario); sin ADR.
+- ADR-016 cubre backfill; no hay ADR de overrides multi-fuente.
+- `docs/datasets/indicadores.md:128` — promesa declarada y no entregada.
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| ADR count | `grep -c "adr/" README.md` | refleja el nuevo ADR tras `make sync-docs` |
+| Doctor | `make doctor` | exit 0 |
+
+## Scope
+
+**In scope**: `docs/adr/ADR-017-*.md` (nuevo), `docs/extraction-lanes.md`,
+`docs/datasets/indicadores.md`.
+**Out of scope**: cambiar el código del override (planes 069/075); elegir
+fuentes alternativas no disponibles (el ADR documenta el estado y el
+escape hatch, no inventa fuentes).
+
+## Steps
+
+### Step 1: Escribe ADR-017
+
+Usa `docs/adr/ADR-016-*.md` como plantilla de formato. Contenido:
+- **Contexto**: mindicador.cl no publica IPC desde 2025-12; el INE es la
+  fuente autoritativa; el agregador es el punto de falla.
+- **Decisión**: cadena multi-fuente con override de último recurso — serie
+  histórica del agregador + variación mensual del INE (HTML anclado, patrón
+  validado desde 2026-05-16); el override es delivery visible (Plan 069).
+- **Estado**: `proposed` — requiere ratificación del mantenedor.
+- **Preguntas abiertas**: ¿API de series del INE cuando exista? ¿UTM tiene
+  un override análogo (SII)? ¿backfill congelado vs retirar la serie?
+
+**Verify**: `test -f docs/adr/ADR-017-*.md` y contiene "override" + "INE".
+
+### Step 2: Documenta en carriles y dataset
+
+Agrega a `docs/extraction-lanes.md` (regla del carril diario) que
+`indicadores` depende del override INE; actualiza
+`docs/datasets/indicadores.md:128` para que la promesa referencie el ADR.
+
+**Verify**: `grep -n "ADR-017" docs/extraction-lanes.md docs/datasets/indicadores.md` → referencias presentes.
+
+### Step 3: Sync
+
+**Verify**: `make sync-docs` (el conteo de ADRs del README sube a 17);
+`make doctor` exit 0.
+
+## Done criteria
+
+- [ ] ADR-017 existe con contexto/decisión/estado/preguntas abiertas
+- [ ] `docs/extraction-lanes.md` menciona el override INE
+- [ ] `docs/datasets/indicadores.md:128` referencia el ADR
+- [ ] `make doctor` exit 0
+- [ ] `plans/README.md` status row updated
+
+## STOP conditions
+
+- El mantenedor rechaza el enfoque de override (el ADR documenta la
+  alternativa de retirar la serie en vez de insistir).
+
+## Maintenance notes
+
+- El ADR hace visible la dependencia frágil y decide el escape hatch
+  (degradar al backfill publicado si el INE rediseña y el regex falla).
+- Si el INE publica una API de series estable, el ADR es el lugar para
+  registrar la migración.

--- a/plans/README.md
+++ b/plans/README.md
@@ -117,7 +117,73 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 
 ## Planes activos
 
-_No hay planes activos — la cola está vacía (2026-08-11)._
+> **Auditoría `/improve deep` 2026-08-12 (commit `53781e2`)**: planes **069–085**
+> (17 hallazgos net-positivos + 4 de dirección). Re-auditoría tras 3 días de
+> cambios densos (release chain, IPC INE, CLI refactor, landing, merge queue).
+> Cuatro subagentes por categoría (correctness/security, perf/deps, tests/DX,
+> docs/direction); todos los hallazgos vetados por el advisor contra el código
+> y los artefactos reales. **Los 3 primeros (069–071) están confirmados en
+> producción** (metadata real, mirror HF real, ZIP real) — son bugs que
+> violan la política declarada, no opiniones.
+
+| # | Plan | Prioridad | Esfuerzo | Riesgo | Depende de | Estado |
+|---|------|----------|----------|--------|-----------|--------|
+| 069 | [Override INE como delivery visible (no enmascarado como backfill)](069-ine-override-delivery-visible.md) | P1 | M | MED | — | TODO |
+| 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | TODO |
+| 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | TODO |
+| 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | TODO |
+| 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | TODO |
+| 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | TODO |
+| 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | TODO |
+| 076 | [RES incremental — descargar solo el año en curso](076-res-incremental-fetch.md) | P2 | M | MED | — | TODO |
+| 077 | [Caracterizar build_dev_db.py (cobertura 21% → ≥60%)](077-characterize-build-dev-db.md) | P2 | L | MED | — | TODO |
+| 078 | [Paralelizar CEAD y geometría (scrapes secuenciales)](078-parallelize-cead-geometria.md) | P2 | M | MED | — | TODO |
+| 079 | [Cobertura de writers y extractores sin test (geo, CEAD, reports)](079-cover-geo-cead-reports.md) | P2 | M | LOW | 077 (helper) | TODO |
+| 080 | [Higiene de tests (red real, sleeps, staleness, e2e, Makefile)](080-test-hygiene-batch.md) | P3 | M | LOW-MED | — | TODO |
+| 081 | [Docs — quickstart R, marcas de carril, inventario de extractores](081-docs-quickstart-lanes-inventory.md) | P3 | S | LOW | — | TODO |
+| 082 | [Mostrar el carril candidate en la landing](082-landing-candidate-lane.md) | P3 | M | MED | 070, 071 | TODO |
+| 083 | [Señal proactiva de review_by inminente](083-review-approaching-signal.md) | P3 | S-M | LOW | — | TODO |
+| 084 | [Promover perfil_territorial_comunal al bundle estable](084-promote-perfil-territorial.md) | P3 (decisión) | S-M | MED | 070, 071 | TODO |
+| 085 | [ADR multi-fuente para el override de IPC](085-adr-multi-source-ipc-override.md) | P3 | M | LOW | 069, 075 | TODO |
+
+## Dependencias y orden recomendado
+
+**Lote 1 (bugs confirmados en producción — P1):**
+069 → 070 → 071. 069 (delivery INE visible) debe preceder a 070 (ambos tocan
+el flujo de indicadores); 071 coordina con 070 en la noción de "publicable".
+
+**Lote 2 (seguridad/consumidor):**
+072, 073 (independientes).
+
+**Lote 3 (correctness del override + perf diaria):**
+074, 075 (el guard del valor INE), 076 (RES incremental, mayor ahorro diario).
+
+**Lote 4 (tests):**
+077 (caracterización build_dev_db, base para 079) → 079 (helper compartido),
+078 (paralelización), 080 (higiene).
+
+**Lote 5 (docs + dirección):**
+081 (docs), 082/083/084/085 (dirección — los 4 requieren decisión o
+ratificación del mantenedor; 084 es decisión de producto).
+
+## Hallazgos considerados y rechazados (2026-08-12)
+
+- **PERF-01 (builds incrementales)**: confirmado correctamente diferido — sin
+  telemetría de duración y con timeout real de CI de 30 min < umbral de 45;
+  el accionable es medir (dentro del lote de perf), no implementar deltas hoy.
+- **PERF-6 (re-lectura de parquet en verify)**: coste aceptado — el guard
+  post-build independiente tiene valor anti-regresión.
+- **PERF-7 (fallback por-comuna de geometría)**: solo aplica en degradación;
+  absorbido por 078 (paralelización).
+- **SECURITY-03 (temp paths fijos)**: race teórico sin ejecución concurrente
+  (CI serializa); registrado, no planificado.
+- **CORRECTNESS-05 (caché de DataFrames no invalidada)**: real pero requiere
+  decisión de API; documentado como follow-up, no plan.
+- **SECURITY-02 (SQL interpolado en sql())**: riesgo limitado al trust domain
+  del catálogo; fragilidad de comillas real pero de bajo impacto; no plan.
+- **DX-05 (cache de staging ~2 GB)**: beneficio incierto; requiere
+  re-verificación en runner; no plan.
+- **TC-04/05 (caracterización restante de tests)**: cubiertos por 077/079/080.
 
 ## Orden de ejecución actualizado (2026-07-26)
 
@@ -128,9 +194,10 @@ _No hay planes activos — la cola está vacía (2026-08-11)._
 > dependen del operador. La secuencia vigente se reduce a los pasos 1–3 de abajo.
 >
 > **Cierre final (2026-08-11)**: con el 064 DONE (2026-07-29) y el 065 DONE y
-> mergeado (PR #54), la secuencia se agotó — **no quedan planes activos**. El 053
-> (plan maestro de geometría) se archivó el mismo día; ver su fila en "Planes
-> archivados (2026-07-24)".
+> mergeado (PR #54), la secuencia se agotó. El 053 (plan maestro de geometría)
+> se archivó el mismo día; ver su fila en "Planes archivados (2026-07-24)".
+> La cola se reabrió con la auditoría 2026-08-12 (planes 069–085, ver
+> "Planes activos").
 
 1. **065** — DONE (2026-08-11): `resolve_by_coords()` implementado y verificado end-to-end contra el artefacto de Pages (ver fila archivada). La cola de planes está vacía.
 

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -520,6 +520,16 @@ class DocsSyncGateGuardrailTests(unittest.TestCase):
         cancel_line = [line for line in content.splitlines() if "cancel-in-progress:" in line][0]
         self.assertNotIn("merge_group", cancel_line)
 
+    def test_required_codeql_check_listens_to_merge_group(self):
+        """CodeQL es un check requerido de la rama: debe escuchar merge_group.
+
+        P1 de la review del PR #61: con CodeQL en los checks requeridos pero
+        sin el trigger merge_group en codeql.yml, cada merge en cola esperaria
+        un check que nunca se reporta y la cola se bloquearia para siempre.
+        """
+        codeql = (ROOT_DIR / ".github" / "workflows" / "codeql.yml").read_text(encoding="utf-8")
+        self.assertIn("merge_group:", codeql)
+
     def test_docs_auto_heal_lives_in_separate_main_only_job(self):
         """El auto-heal debe vivir en un job separado (docs-autosync),
         condicionado a push a main, NUNCA en el job quality (que debe

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -505,6 +505,21 @@ class DocsSyncGateGuardrailTests(unittest.TestCase):
         content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("python scripts/sync_docs.py --check", content)
 
+    def test_pipeline_workflow_listens_to_merge_group(self):
+        """El workflow de Pipeline Check debe escuchar el evento merge_group.
+
+        Requisito de la merge queue de GitHub: la cola crea ramas temporales
+        gh-readonly-queue/main/... y dispara el evento merge_group; sin este
+        trigger, los checks requeridos nunca se reportan y la cola falla todos
+        los merges. Sin esto, habilitar "Require merge queue" en la branch
+        protection romperia todos los merges futuros.
+        """
+        content = PIPELINE_CHECK_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("merge_group:", content)
+        # La cola no debe cancelar builds en curso (prueba varios PRs en paralelo).
+        cancel_line = [line for line in content.splitlines() if "cancel-in-progress:" in line][0]
+        self.assertNotIn("merge_group", cancel_line)
+
     def test_docs_auto_heal_lives_in_separate_main_only_job(self):
         """El auto-heal debe vivir en un job separado (docs-autosync),
         condicionado a push a main, NUNCA en el job quality (que debe


### PR DESCRIPTION
## Contexto

La merge queue de GitHub elimina de raíz la carrera release-vs-merge: un release pushea el bump de versión entre la creación de un PR y su merge, y el CI del merge fallaba el gate de docs pese a no haber regresión (3 veces el 2026-08-12). Con la cola, los checks corren contra el estado final (main + PR + PRs en cola) antes de mergear.

## Por qué este PR

GitHub **no expone API** para habilitar "Require merge queue" (solo UI), pero exige preparar el lado código: **sin el evento `merge_group` en el workflow, los checks requeridos nunca se reportan en la cola y TODOS los merges fallan**. Este PR deja el repo listo.

## Cambios

- `pipeline-check.yml`: agrega `merge_group` a los triggers (la cola crea ramas temporales `gh-readonly-queue/main/...` y dispara este evento). Cada PR en cola tiene su propio ref/grupo de concurrency; NO se cancela en merge_group (la cola prueba varios PRs en paralelo).
- Guardrail: `test_ci_config.py` (merge_group presente + no cancelar en la cola).
- `docs/release.md`: sección "Merge queue" — mergear con `gh pr merge --auto`, config de UI, limitaciones.

## Para activar la cola (manual, 30s)

Settings → Branches → regla de `main` → **Require merge queue**. Con este PR mergeado, la cola funciona; sin él, activarla rompería todos los merges.

## Verificación
- Suite 860 tests + 1 skip, lint, format, doctor verdes.
- YAML del workflow válido.