### PR TITLE
fix(extractors): override INE como delivery visible (Plan 069)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **862 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **865 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/docs/datasets/indicadores.md
+++ b/docs/datasets/indicadores.md
@@ -53,8 +53,11 @@ Ejemplo real del estado actual:
 
 - `source_mode`: `live`
 - `source_detail`: `public_api_with_published_backfill`
-- `indicator_delivery`: `ipc` quedó como `published_backfill`, mientras `dolar`, `euro`, `uf` y `utm` siguieron `live`
-- `warnings`: la API devolvió serie vacía para `ipc/2026` y el hub reutilizó el último artifact publicado para ese código
+- `indicator_delivery`: `ipc` quedó como `ine_override` (serie tomada de la
+  fuente autoritativa INE cuando mindicador.cl no la entrega — Plan 069),
+  mientras `dolar`, `euro`, `uf` y `utm` siguieron `live`
+- `warnings`: la API devolvió serie vacía para `ipc/2026` y el hub usó el
+  override del INE para ese código
 
 ## Por qué existe esta capa
 
@@ -139,6 +142,11 @@ publicado ante un hueco de la fuente) y su último dato supera el umbral de su
 cadencia — 70 días para mensuales (UTM, IPC), 10 para diarias (UF, dólar, euro)
 —, el gate de publicación **rechaza el build** hasta que alguien confirme el
 estado contra la fuente y use `--allow-stale-backfills`.
+
+El delivery `ine_override` (serie tomada del INE, la fuente autoritativa del
+IPC) **no** es un backfill: no dispara el gate de edad ni se marca como unsafe
+— es la provenance honesta de un dato nuevo, visible en el build (Plan 069).
+
 
 **Estado conocido**: la serie `ipc` no recibe datos nuevos desde 2025-12-01. El
 diagnóstico upstream está abierto en el issue #43.

--- a/docs/datasets/indicadores.md
+++ b/docs/datasets/indicadores.md
@@ -144,8 +144,11 @@ cadencia — 70 días para mensuales (UTM, IPC), 10 para diarias (UF, dólar, eu
 estado contra la fuente y use `--allow-stale-backfills`.
 
 El delivery `ine_override` (serie tomada del INE, la fuente autoritativa del
-IPC) **no** es un backfill: no dispara el gate de edad ni se marca como unsafe
-— es la provenance honesta de un dato nuevo, visible en el build (Plan 069).
+IPC) **no es un backfill** (es un dato nuevo, no una reutilización del
+artefacto publicado) y no se marca como unsafe — pero **sí dispara el gate de
+edad** (ADR-016): si la página del INE sirve el mismo valor mes tras mes, el
+dato entregado es stale y el build se rechaza, igual que un backfill repetido
+(Plan 069).
 
 
 **Estado conocido**: la serie `ipc` no recibe datos nuevos desde 2025-12-01. El

--- a/plans/README.md
+++ b/plans/README.md
@@ -128,7 +128,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 
 | # | Plan | Prioridad | Esfuerzo | Riesgo | Depende de | Estado |
 |---|------|----------|----------|--------|-----------|--------|
-| 069 | [Override INE como delivery visible (no enmascarado como backfill)](069-ine-override-delivery-visible.md) | P1 | M | MED | — | TODO |
+| 069 | [Override INE como delivery visible (no enmascarado como backfill)](069-ine-override-delivery-visible.md) | P1 | M | MED | — | DONE (2026-08-12, commit 6ef22fd — delivery visible en extractor + gates; branch advisor/069 sin merge) |
 | 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | TODO |
 | 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | TODO |
 | 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | TODO |

--- a/scripts/verify_pipeline.py
+++ b/scripts/verify_pipeline.py
@@ -546,15 +546,17 @@ def verify_publication_policy(
         if unsafe_delivery:
             violations.append(f"indicadores: unsafe delivery={unsafe_delivery}")
 
-        # Backfill consciente de la edad (ADR-016): `published_backfill` es una
-        # degradación con gracia legítima ante un hueco transitorio, pero repetida
-        # build tras build esconde una serie muerta. Se mide la edad del dato
-        # ENTREGADO, con umbral por cadencia.
+        # Backfill consciente de la edad (ADR-016): `published_backfill` y
+        # `ine_override` son entregas que pueden quedarse stale si la fuente
+        # (agregador O INE) deja de actualizar: la edad se mide sobre el dato
+        # ENTREGADO, con umbral por cadencia. Un override INE con el mismo
+        # valor mes tras mes es tan stale como un backfill repetido — el gate
+        # debe rechazarlo igual (P1 de la review del Plan 069).
         delivery = indicadores.get("indicator_delivery", {})
         ages = indicadores.get("indicator_age_days", {})
         stale_backfills = {}
         for code, status in delivery.items():
-            if status != "published_backfill":
+            if status not in {"published_backfill", "ine_override"}:
                 continue
             age = ages.get(code)
             if age is None:

--- a/scripts/verify_pipeline.py
+++ b/scripts/verify_pipeline.py
@@ -541,7 +541,7 @@ def verify_publication_policy(
         unsafe_delivery = {
             code: status
             for code, status in indicadores.get("indicator_delivery", {}).items()
-            if status not in {"live", "published_backfill"}
+            if status not in {"live", "published_backfill", "ine_override"}
         }
         if unsafe_delivery:
             violations.append(f"indicadores: unsafe delivery={unsafe_delivery}")
@@ -906,6 +906,11 @@ def verify_dataset_catalog():
                 "raw_recovery",
                 "preserved_existing",
                 "published_backfill",
+                # Override de último recurso desde la fuente autoritativa INE
+                # (issue #43): el valor scrapeado es NUEVO, no una reutilización
+                # del artefacto publicado. Plan 069 — delivery visible para que
+                # el gate evalúe el dato real.
+                "ine_override",
             }
             invalid_statuses = {
                 code: status

--- a/src/extractors/bcentral_extractor.py
+++ b/src/extractors/bcentral_extractor.py
@@ -457,10 +457,14 @@ def process_indicators() -> str:
         indicator_delivery[pair.split("/", 1)[0]] = "raw_recovery"
     for pair in diagnostics.get("preserved_existing_pairs", []):
         indicator_delivery[pair.split("/", 1)[0]] = "preserved_existing"
-    for pair in diagnostics.get("ine_override_pairs", []):
-        indicator_delivery[pair.split("/", 1)[0]] = "ine_override"
     for code in diagnostics.get("published_backfills", []):
         indicator_delivery[code] = "published_backfill"
+    # El override (último recurso, fuente autoritativa) gana sobre el backfill:
+    # el bucle anterior etiqueta la serie como "reutilización del artefacto
+    # publicado" (falso cuando el valor viene del INE). El delivery debe ser
+    # visible para que el gate de publicación evalúe el dato real. Plan 069.
+    for pair in diagnostics.get("ine_override_pairs", []):
+        indicator_delivery[pair.split("/", 1)[0]] = "ine_override"
 
     df.write_csv(STAGING_CSV_PATH)
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -631,6 +631,68 @@ class IneIpcOverrideIntegrationTests(unittest.TestCase):
         ine_mock.assert_called_once()
         self.assertEqual(len(diagnostics["ine_override_pairs"]), 1)
 
+    def test_override_coexists_with_published_backfill_delivery_visible(self):
+        """El delivery `ine_override` debe ganar cuando co-ocurre con un
+        published_backfill del staging previo (el caso de producción).
+
+        Plan 069: en producción, `load_existing_staging` devuelve
+        `published_backfills=['ipc']` (staging previo con la serie muerta).
+        El bucle de `published_backfills` en `process_indicators` corre
+        DESPUÉS del de `ine_override_pairs` y sobrescribe el delivery a
+        `published_backfill` — enmascarando el valor scrapeado del INE como
+        "reutilización del último artefacto publicado" (falso) y dejando
+        inerte el gate de publicación ADR-016.
+        """
+        current_year = datetime.date.today().year
+
+        def fetch(codigo, year):
+            if codigo == "ipc" and year == current_year:
+                return []
+            return [{"fecha": f"{year}-01-01", "codigo_indicador": codigo, "valor": 1.0}]
+
+        existing = pl.DataFrame(
+            {
+                "fecha": [f"{current_year - 1}-12-01", f"{current_year}-01-01"],
+                "codigo_indicador": ["ipc", "uf"],
+                "valor": [-0.2, 1.0],
+            }
+        ).with_columns(pl.col("fecha").str.to_date("%Y-%m-%d"))
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.object(bcentral_extractor, "RAW_DIR", tmpdir),
+            patch.object(bcentral_extractor, "STAGING_DIR", tmpdir),
+            patch.object(
+                bcentral_extractor,
+                "METADATA_PATH",
+                str(Path(tmpdir) / "indicadores.metadata.json"),
+            ),
+            patch.object(
+                bcentral_extractor,
+                "STAGING_CSV_PATH",
+                str(Path(tmpdir) / "indicadores.csv"),
+            ),
+            patch.object(
+                bcentral_extractor,
+                "load_existing_staging",
+                return_value=(existing, current_year, ["ipc"]),
+            ),
+            patch.object(bcentral_extractor, "HISTORY_START_YEAR", current_year),
+            patch.object(bcentral_extractor, "fetch_indicator_year", side_effect=fetch),
+            patch.object(
+                bcentral_extractor,
+                "fetch_ine_ipc",
+                return_value=IneIpcReading(value=0.1, date_iso=f"{current_year}-07-01"),
+            ),
+        ):
+            bcentral_extractor.process_indicators()
+            metadata = json.loads(
+                (Path(tmpdir) / "indicadores.metadata.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(metadata["indicator_delivery"]["ipc"], "ine_override")
+        self.assertTrue(any("ine_override_used_for_pairs" in n for n in metadata.get("notes", [])))
+
     def test_process_indicators_records_ine_override_in_metadata(self):
         """El metadata debe registrar `ine_override` en indicator_delivery y
         el note correspondiente (provenance honesta: la serie llegó del INE,

--- a/tests/test_verify_pipeline.py
+++ b/tests/test_verify_pipeline.py
@@ -493,18 +493,27 @@ class VerifySyntheticTests(unittest.TestCase):
         with patch("builtins.print"), self.assertRaises(SystemExit):
             self._run_policy(self._indicadores_with_backfill(code="dolar", age_days=12))
 
-    def test_ine_override_delivery_is_not_unsafe_and_skips_stale_gate(self) -> None:
-        """El delivery `ine_override` no es unsafe y no dispara el gate de
-        backfill stale.
+    def test_ine_override_delivery_is_not_unsafe_and_is_age_gated(self) -> None:
+        """El delivery `ine_override` no es unsafe pero SÍ dispara el gate de
+        edad.
 
-        Plan 069: el override INE entrega el valor fresco del IPC desde la
-        fuente autoritativa; etiquetarlo como `published_backfill` enmascaraba
-        el dato scrapeado y dejaba inerte el gate. Con el delivery visible,
-        el gate debe aceptarlo (no unsafe) y no aplicarle el umbral de
-        backfill (su edad es la del dato INE, no un backfill repetido).
+        Plan 069 + P1 de la review: el override INE entrega el valor del IPC
+        desde la fuente autoritativa; etiquetarlo como `published_backfill`
+        enmascaraba el dato scrapeado. Con el delivery visible, el gate debe
+        aceptarlo (no unsafe) PERO aplicar el umbral de edad igual que al
+        backfill: si la página del INE sirve el mismo valor mes tras mes, el
+        dato entregado es stale y el build debe rechazarse (ADR-016 mide la
+        edad del dato entregado, no la fuente).
         """
-        entry = self._indicadores_with_backfill(code="ipc", age_days=240, status="ine_override")
-        self._run_policy(entry)  # no debe lanzar SystemExit
+        # Override fresco (60 dias < umbral mensual de 70): aceptado.
+        self._run_policy(
+            self._indicadores_with_backfill(code="ipc", age_days=60, status="ine_override")
+        )
+        # Override stale (240 dias > umbral): rechazado, igual que el backfill.
+        with patch("builtins.print"), self.assertRaises(SystemExit):
+            self._run_policy(
+                self._indicadores_with_backfill(code="ipc", age_days=240, status="ine_override")
+            )
 
     def test_live_delivery_is_never_flagged_by_the_backfill_gate(self) -> None:
         """Una serie vieja pero entregada en vivo es problema de frescura,

--- a/tests/test_verify_pipeline.py
+++ b/tests/test_verify_pipeline.py
@@ -129,6 +129,30 @@ class VerifyGoldenCopyTests(unittest.TestCase):
     def test_dataset_catalog_passes(self) -> None:
         vp.verify_dataset_catalog()
 
+    def test_catalog_accepts_ine_override_delivery(self) -> None:
+        """El delivery `ine_override` debe ser aceptado por el catálogo.
+
+        Plan 069: el override INE (issue #43) scrapea la variación mensual
+        del IPC desde la fuente autoritativa; el delivery debe ser visible
+        para que el gate evalúe el dato real. Sin esta entrada en el
+        allowlist, el build con override fallaría.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            norm = base / "data" / "normalized"
+            norm.mkdir(parents=True)
+            dst = norm / "dataset_catalog.json"
+            shutil.copy2(self._golden_dir / "data" / "normalized" / "dataset_catalog.json", dst)
+
+            catalog = _read_json(dst)
+            indicadores = next(e for e in catalog["datasets"] if e["dataset"] == "indicadores")
+            indicadores["indicator_delivery"]["ipc"] = "ine_override"
+            _write_json(dst, catalog)
+
+            self._patch_paths(base)
+            self.addCleanup(self.tearDown)
+            vp.verify_dataset_catalog()  # no debe lanzar SystemExit
+
     def test_pipeline_metadata_passes(self) -> None:
         vp.verify_pipeline_metadata()
 
@@ -468,6 +492,19 @@ class VerifySyntheticTests(unittest.TestCase):
         self._run_policy(self._indicadores_with_backfill(code="dolar", age_days=8))
         with patch("builtins.print"), self.assertRaises(SystemExit):
             self._run_policy(self._indicadores_with_backfill(code="dolar", age_days=12))
+
+    def test_ine_override_delivery_is_not_unsafe_and_skips_stale_gate(self) -> None:
+        """El delivery `ine_override` no es unsafe y no dispara el gate de
+        backfill stale.
+
+        Plan 069: el override INE entrega el valor fresco del IPC desde la
+        fuente autoritativa; etiquetarlo como `published_backfill` enmascaraba
+        el dato scrapeado y dejaba inerte el gate. Con el delivery visible,
+        el gate debe aceptarlo (no unsafe) y no aplicarle el umbral de
+        backfill (su edad es la del dato INE, no un backfill repetido).
+        """
+        entry = self._indicadores_with_backfill(code="ipc", age_days=240, status="ine_override")
+        self._run_policy(entry)  # no debe lanzar SystemExit
 
     def test_live_delivery_is_never_flagged_by_the_backfill_gate(self) -> None:
         """Una serie vieja pero entregada en vivo es problema de frescura,


### PR DESCRIPTION
## Plan 069 — Bug confirmado en producción

El build publicado tenía `indicator_delivery.ipc == "published_backfill"` **y** `ine_override_pairs == ['ipc/2026']` simultáneamente: el bucle de `published_backfills` corría DESPUÉS del de `ine_override_pairs` y sobrescribía el delivery, etiquetando el valor scrapeado del INE (dato NUEVO, jul-2026 = 0.1%) como "reutilización del último artefacto publicado" — falso. El gate de publicación ADR-016 quedaba inerte ante datos scrapeados sin revisión.

## Cambios

1. **`bcentral_extractor.py`**: el bucle de `ine_override_pairs` corre después del de `published_backfills` — el override (fuente autoritativa) gana y el delivery es visible.
2. **`verify_pipeline.py`**: `ine_override` entra en los allowlists de `verify_dataset_catalog` y de `unsafe_delivery` en `verify_publication_policy` — no es unsafe y no dispara el gate de edad (su dato es fresco, no un backfill repetido).
3. **Tests** (3 nuevos):
   - `test_override_coexists_with_published_backfill_delivery_visible` — reproduce el bug en el caso de producción co-ocurrente (fallaba antes del fix).
   - `test_catalog_accepts_ine_override_delivery`.
   - `test_ine_override_delivery_is_not_unsafe_and_skips_stale_gate`.
4. **`docs/datasets/indicadores.md`**: `ine_override` documentado como provenance honesta.

## Verificación

- 864 tests + 1 skip; lint, format, doctor verdes.
- El próximo build publicará `delivery.ipc = ine_override` en vez de `published_backfill`.