### PR TITLE
fix(hf): el mirror filtra por publication_track del registry (Plan 070)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -747,7 +747,8 @@ Corre tras un `Pipeline Check` exitoso en `main` (`workflow_run`) o
 verificado, corre `python-semantic-release` (§7), publica el paquete en PyPI y
 adjunta los artefactos de datos al GitHub Release cuando son
 publication-grade. Tras cada release, el job `hf-publish` de
-`pypi-release.yml` replica las 19 capas publicables (Parquet + catálogo) a
+`pypi-release.yml` replica las 17 capas publicables (Parquet + catálogo, las
+estables por `publication_track` del registry — Plan 070) a
 Hugging Face Hub (`cortega26/chile-hub`, requiere secret `HF_TOKEN`); nunca
 incluye el carril `candidate` y no bloquea el release si falla.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **865 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **867 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/docs/hf/dataset-card.md
+++ b/docs/hf/dataset-card.md
@@ -8,7 +8,7 @@ size_categories: [100K<n<1M]
 
 # chile-hub
 
-Datos públicos de Chile curados, normalizados y validados — 19 capas
+Datos públicos de Chile curados, normalizados y validados — {{DATASET_COUNT}} capas
 (DPA, Censo 2024, indicadores económicos, salud, educación, finanzas
 municipales, electoral y más). Espejo en Hugging Face Hub del bundle oficial
 publicado en GitHub Releases: https://github.com/cortega26/chile-hub

--- a/plans/README.md
+++ b/plans/README.md
@@ -129,7 +129,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | # | Plan | Prioridad | Esfuerzo | Riesgo | Depende de | Estado |
 |---|------|----------|----------|--------|-----------|--------|
 | 069 | [Override INE como delivery visible (no enmascarado como backfill)](069-ine-override-delivery-visible.md) | P1 | M | MED | — | DONE (2026-08-12, commit 6ef22fd — delivery visible en extractor + gates; branch advisor/069 sin merge) |
-| 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | TODO |
+| 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | DONE (2026-08-12, commit d34462f — registry como fuente de carril; branch advisor/070 sin merge) |
 | 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | TODO |
 | 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | TODO |
 | 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | TODO |

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -211,6 +211,11 @@ def main(argv: list[str] | None = None) -> None:
             repo_id=args.repo_id,
             repo_type="dataset",
             commit_message=f"chore(data): publish chile-hub {version}",
+            # upload_folder NO sincroniza borrados remotos: sin delete_patterns,
+            # un parquet candidate subido en releases anteriores (Plan 070) se
+            # quedaria en el mirror para siempre. Se borran explicitamente los
+            # parquets que ya no pertenecen al set publicable.
+            delete_patterns=["data/*.parquet"],
         )
         print(f"Publicado {args.repo_id} (chile-hub {version}).")
 

--- a/scripts/publish_hf_dataset.py
+++ b/scripts/publish_hf_dataset.py
@@ -2,11 +2,13 @@
 
 Canal de *descubrimiento* (complementa el Plan 051 = capa de acceso HTTP
 estática). Copia los Parquet de las capas publicables (carril
-`stable_publishable`, `outputs` presente y `reuse_policy.redistribution_ok`)
-más los JSON de catálogo a un directorio de staging, genera un README desde
-la plantilla de `docs/hf/dataset-card.md`, y sube ese directorio a
-`huggingface_hub`. El carril `candidate` queda excluido por construcción
-(nunca tiene `outputs`).
+`stable_publishable` en `data/source_registry.json`, `outputs` presente y
+`reuse_policy.redistribution_ok`) más los JSON de catálogo a un directorio
+de staging, genera un README desde la plantilla de `docs/hf/dataset-card.md`,
+y sube ese directorio a `huggingface_hub`. El carril `candidate` queda
+excluido por `publication_track` del registry (Plan 070: antes se infería de
+`outputs`, asunción que el build violaba — candidate con outputs como perfil
+y consumo llegaron al mirror).
 
 `huggingface_hub` se importa de forma perezosa: el script corre en modo
 `--dry-run` sin la dependencia instalada; sólo la necesita el modo de subida
@@ -23,6 +25,7 @@ import tomllib
 ROOT_DIR = Path(__file__).resolve().parents[1]
 NORMALIZED_DIR = ROOT_DIR / "data" / "normalized"
 CATALOG_PATH = ROOT_DIR / "data" / "dataset_catalog_config.json"
+SOURCE_REGISTRY_PATH = ROOT_DIR / "data" / "source_registry.json"
 CARD_TEMPLATE_PATH = ROOT_DIR / "docs" / "hf" / "dataset-card.md"
 PYPROJECT_PATH = ROOT_DIR / "pyproject.toml"
 
@@ -31,18 +34,41 @@ PYPROJECT_PATH = ROOT_DIR / "pyproject.toml"
 CATALOG_JSON_FILES = ["datapackage.json", "dataset_catalog.json", "artifact_manifest.json"]
 
 
-def _read_catalog() -> dict:
+def _read_json(path: Path) -> dict:
     import json
 
-    with open(CATALOG_PATH, "r", encoding="utf-8") as f:
+    with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 
-def select_publishable_files() -> tuple[list[tuple[str, Path]], list[Path]]:
-    """Selecciona los archivos publicables desde el catálogo.
+def _read_catalog() -> dict:
+    return _read_json(CATALOG_PATH)
 
-    Sólo capas con ``outputs`` truthy (carril `stable_publishable`; el
-    carril `candidate` nunca declara `outputs`) **y**
+
+def _read_source_registry() -> dict:
+    """Carril por dataset: fuente única en `data/source_registry.json`.
+
+    El catálogo construido (`dataset_catalog_config.json`) declara `outputs`
+    también para candidate (perfil_territorial_comunal, consumo_electrico —
+    Plan 070): inferir el carril de `outputs` era falso y dejó que el mirror
+    de HF publicara 2 capas candidate como publicables. El registry es la
+    fuente de verdad del carril (AGENTS.md §1).
+    """
+    data = _read_json(SOURCE_REGISTRY_PATH)
+    entries = data if isinstance(data, list) else list(data.values())
+    return {
+        entry["dataset"]: entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("dataset")
+    }
+
+
+def select_publishable_files() -> tuple[list[tuple[str, Path]], list[Path]]:
+    """Selecciona los archivos publicables desde el catálogo y el registry.
+
+    Sólo capas con ``publication_track == "stable_publishable"`` en
+    `source_registry.json` (carril candidate/deprecated excluido por
+    construcción — Plan 070), ``outputs`` truthy **y**
     ``reuse_policy.redistribution_ok is True``. Falla ruidoso si alguna capa
     publicable carece de su Parquet en disco (drift entre catálogo y build).
 
@@ -52,13 +78,21 @@ def select_publishable_files() -> tuple[list[tuple[str, Path]], list[Path]]:
     porque ``comunas_enriquecidas`` es un alias intencional que apunta al
     mismo Parquet que ``comunas`` (ver Plan 014/PERF-08): sin este renombre,
     ambas claves colapsarían al mismo archivo de destino y el mirror de HF
-    tendría 18 archivos en vez de las 19 capas publicables reales.
+    tendría 18 archivos en vez de las 17 capas publicables reales.
     """
     catalog = _read_catalog()
+    registry = _read_source_registry()
     parquet_entries: list[tuple[str, Path]] = []
     for name, entry in sorted(catalog.items()):
         outputs = entry.get("outputs")
         if not outputs:
+            continue
+        registry_entry = registry.get(name, {})
+        track = registry_entry.get("publication_track")
+        if track != "stable_publishable":
+            # Candidate/deprecated: documentado, no es un error — el carril
+            # candidate puede declarar outputs en el catálogo (Plan 070).
+            print(f"  [skip] {name}: publication_track={track!r} — fuera del mirror HF.")
             continue
         if entry.get("reuse_policy", {}).get("redistribution_ok") is not True:
             raise SystemExit(
@@ -90,10 +124,11 @@ def select_publishable_files() -> tuple[list[tuple[str, Path]], list[Path]]:
     return parquet_entries, catalog_json_files
 
 
-def _build_dataset_table(catalog: dict) -> str:
+def _build_dataset_table(catalog: dict, selected_names: set[str]) -> str:
+    """Tabla de la card con SOLO las capas seleccionadas para publicar."""
     rows = ["| Dataset | Filas aprox. | Licencia |", "|:---|---:|:---|"]
     for name, entry in sorted(catalog.items()):
-        if not entry.get("outputs"):
+        if name not in selected_names:
             continue
         record_count = entry.get("expected_record_count", "N/D")
         license_name = entry.get("reuse_policy", {}).get("license", "N/D")
@@ -121,7 +156,11 @@ def build_staging_dir(
 
     catalog = _read_catalog()
     template = CARD_TEMPLATE_PATH.read_text(encoding="utf-8")
-    card = template.replace("{{DATASET_TABLE}}", _build_dataset_table(catalog))
+    # La card se genera con el conteo y la tabla REALES de lo publicado
+    # (Plan 070: antes decía 19 capas fijas y listaba candidate).
+    table = _build_dataset_table(catalog, {name for name, _ in parquet_entries})
+    card = template.replace("{{DATASET_TABLE}}", table)
+    card = card.replace("{{DATASET_COUNT}}", str(len(parquet_entries)))
     (dest / "README.md").write_text(card, encoding="utf-8")
 
 

--- a/tests/e2e/verify_059.sh
+++ b/tests/e2e/verify_059.sh
@@ -3,14 +3,14 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
-echo "-- make build && publish_hf_dataset.py --dry-run lista 19 parquet --"
+echo "-- make build && publish_hf_dataset.py --dry-run lista 17 parquet --"
 make build >/dev/null
 DRY_RUN_OUTPUT="$(.venv/bin/python scripts/publish_hf_dataset.py --dry-run)"
 echo "$DRY_RUN_OUTPUT"
-test "$(echo "$DRY_RUN_OUTPUT" | grep -c 'data/.*\.parquet')" = "19"
+test "$(echo "$DRY_RUN_OUTPUT" | grep -c 'data/.*\.parquet')" = "17"
 
 echo "-- el dry-run NO lista datasets del carril candidate --"
-test "$(echo "$DRY_RUN_OUTPUT" | grep -c 'delincuencia_comunal\|autoridades_locales\|geometria_comunal')" = "0"
+test "$(echo "$DRY_RUN_OUTPUT" | grep -c 'delincuencia_comunal\|autoridades_locales\|geometria_comunal\|perfil_territorial_comunal\|consumo_electrico_comunal')" = "0"
 git checkout -- data/normalized/ README.md index.html 2>/dev/null || true
 make sync-docs >/dev/null
 

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -702,6 +702,42 @@ class HfPublishJobGuardrailTests(unittest.TestCase):
         self.assertIn("redistribution_ok", content)
         self.assertIn("--dry-run", content)
 
+    def test_publish_script_filters_by_publication_track_from_registry(self):
+        """El script HF debe filtrar por `publication_track` del registry, no
+        inferir el carril de `outputs` del catálogo.
+
+        Plan 070: la asunción "candidate nunca declara outputs" era falsa —
+        perfil_territorial_comunal y consumo_electrico_comunal (candidate,
+        el segundo deprecated) tienen outputs y llegaron al mirror HF como
+        si fueran publicables. El registry es la fuente de verdad del carril.
+        """
+        content = PUBLISH_HF_SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("SOURCE_REGISTRY_PATH", content)
+        self.assertIn("publication_track", content)
+        self.assertIn('track != "stable_publishable"', content)
+
+    def test_publish_script_dry_run_excludes_candidate_and_deprecated(self):
+        """El dry-run debe listar 17 capas (no 19): candidate/deprecated fuera.
+
+        Regresión del Plan 070: con el catálogo real, perfil y consumo (ambos
+        candidate) no deben aparecer en la lista de parquets del mirror.
+        """
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, str(PUBLISH_HF_SCRIPT), "--dry-run"],
+            capture_output=True,
+            text=True,
+            cwd=ROOT_DIR,
+            env={**__import__("os").environ, "HF_TOKEN": "x"},
+            timeout=120,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("data/regiones.parquet", result.stdout)
+        self.assertNotIn("data/perfil_territorial_comunal.parquet", result.stdout)
+        self.assertNotIn("data/consumo_electrico_comunal.parquet", result.stdout)
+
     def test_workflow_never_names_candidate_lane_datasets(self):
         """El carril candidate se excluye por construcción (ausencia de
         `outputs` en el catálogo) — nunca por una lista hardcodeada en el


### PR DESCRIPTION
## Plan 070 — Bug confirmado en producción

El mirror `cortega26/chile-hub` tenía 19 parquets, incluyendo `consumo_electrico_comunal` (fuente muerta, deprecated, 3 filas de muestra) y `perfil_territorial_comunal` (candidate), como si fueran capas publicables. El script infería el carril de `outputs` del catálogo — asunción falsa: el build declara `outputs` para candidate.

## Cambios

1. **`publish_hf_dataset.py`**: `select_publishable_files` lee `source_registry.json` (fuente única de carril, AGENTS.md §1) y exige `publication_track == "stable_publishable"`; candidate/deprecated se saltan con skip explícito.
2. **Card HF**: conteo y tabla REALES de lo publicado (`{{DATASET_COUNT}}` dinámico; `_build_dataset_table` recibe el set seleccionado) — antes decía "19 capas" fijas y listaba candidate.
3. **Tests**: guardrail de filtrado por registry + test de dry-run (subprocess) que verifica 17 capas sin candidate.

## Verificación

- Dry-run: 17 parquets, skip explícito de las 2 candidate.
- Suite 866 tests + 1 skip; lint, format, doctor verdes.
- AGENTS.md ("nunca incluye candidate") ahora es verdad — el mirror publicado se re-verifica en el próximo release.