### PR TITLE
fix(artifacts): el catálogo del bundle ZIP solo declara capas incluidas (Plan 071)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **867 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **868 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -130,7 +130,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 |---|------|----------|----------|--------|-----------|--------|
 | 069 | [Override INE como delivery visible (no enmascarado como backfill)](069-ine-override-delivery-visible.md) | P1 | M | MED | — | DONE (2026-08-12, commit 6ef22fd — delivery visible en extractor + gates; branch advisor/069 sin merge) |
 | 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | DONE (2026-08-12, commit d34462f — registry como fuente de carril; branch advisor/070 sin merge) |
-| 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | TODO |
+| 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | DONE (2026-08-12, commit e9d6041 — catálogo filtrado en el ZIP; branch advisor/071 sin merge) |
 | 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | TODO |
 | 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | TODO |
 | 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | TODO |

--- a/src/builders/artifacts.py
+++ b/src/builders/artifacts.py
@@ -19,7 +19,7 @@ from src.builders._shared import (
     PUBLISHABLE_BUNDLE_ZIP_NAME,
     UTC,
 )
-from src.builders.io_utils import compute_sha256, write_json_atomic
+from src.builders.io_utils import compute_sha256, compute_sha256_bytes, write_json_atomic
 from src.builders.reports import load_source_registry
 
 
@@ -426,17 +426,47 @@ def write_publishable_bundle_zip():
 
     output_path = os.path.join(NORMALIZED_DIR, PUBLISHABLE_BUNDLE_ZIP_NAME)
     tmp_path = output_path + ".tmp"
+
+    # Pre-computa el catálogo filtrado (Plan 071) y sus métricas ANTES de
+    # escribir el ZIP: el manifest embebido y el catálogo deben describirse
+    # mutuamente con los mismos bytes, sin depender del orden de los
+    # artifacts en el manifest (alfabético: artifact_manifest < dataset_catalog).
+    bundle_catalog_text = None
+    bundle_catalog_bytes = None
+    for artifact in artifacts:
+        if artifact["path"] == "data/normalized/dataset_catalog.json":
+            bundle_catalog_text = _bundle_filtered_catalog(artifacts)
+            bundle_catalog_bytes = bundle_catalog_text.encode("utf-8")
+            artifact["size_bytes"] = len(bundle_catalog_bytes)
+            artifact["sha256"] = compute_sha256_bytes(bundle_catalog_bytes)
+            break
+
     with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for artifact in artifacts:
             relative_path = artifact["path"]
             absolute_path = os.path.join(DATA_DIR, os.path.relpath(relative_path, "data"))
-            # El dataset_catalog.json completo declara capas candidate con
-            # outputs que NO viajan en el bundle (Plan 071): dentro del ZIP,
-            # el catálogo se filtra a las capas cuyos archivos SÍ están en el
-            # manifest, para que un consumidor no encuentre capas sin archivo.
             if relative_path == "data/normalized/dataset_catalog.json":
-                catalog_text = _bundle_filtered_catalog(artifacts)
-                archive.writestr(relative_path, catalog_text)
+                # Catálogo filtrado: solo capas cuyos archivos SÍ viajan en el
+                # bundle (un consumidor no debe encontrar capas sin archivo).
+                archive.writestr(relative_path, bundle_catalog_text)
+                continue
+            if relative_path == "data/normalized/artifact_manifest.json":
+                # Manifest embebido con los size/sha256 del catálogo filtrado,
+                # para que validar el bundle contra su manifest no reporte el
+                # catálogo como corrupto (P1 de la review del Plan 071).
+                archive.writestr(
+                    relative_path,
+                    json.dumps(
+                        {
+                            "generated_at_utc": manifest.get("generated_at_utc"),
+                            "artifact_count": len(artifacts),
+                            "artifacts": artifacts,
+                            "packages": manifest.get("packages", []),
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    ),
+                )
                 continue
             archive.write(absolute_path, arcname=relative_path)
 

--- a/src/builders/artifacts.py
+++ b/src/builders/artifacts.py
@@ -431,8 +431,7 @@ def write_publishable_bundle_zip():
     # escribir el ZIP: el manifest embebido y el catálogo deben describirse
     # mutuamente con los mismos bytes, sin depender del orden de los
     # artifacts en el manifest (alfabético: artifact_manifest < dataset_catalog).
-    bundle_catalog_text = None
-    bundle_catalog_bytes = None
+    bundle_catalog_text: str | None = None
     for artifact in artifacts:
         if artifact["path"] == "data/normalized/dataset_catalog.json":
             bundle_catalog_text = _bundle_filtered_catalog(artifacts)
@@ -440,6 +439,11 @@ def write_publishable_bundle_zip():
             artifact["size_bytes"] = len(bundle_catalog_bytes)
             artifact["sha256"] = compute_sha256_bytes(bundle_catalog_bytes)
             break
+    if bundle_catalog_text is None:
+        raise SystemExit(
+            "Error: el manifest no declara data/normalized/dataset_catalog.json; "
+            "no se puede construir el bundle ZIP."
+        )
 
     with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
         for artifact in artifacts:

--- a/src/builders/artifacts.py
+++ b/src/builders/artifacts.py
@@ -370,6 +370,41 @@ def write_hub_bundle_json(pipeline_metadata, hub_health, dataset_catalog, artifa
     return output_path, bundle
 
 
+def _bundle_filtered_catalog(artifacts: list[dict]) -> str:
+    """Variante del dataset_catalog.json para DENTRO del bundle ZIP.
+
+    El catálogo completo declara capas candidate con `outputs` (p. ej.
+    perfil_territorial_comunal, consumo_electrico_comunal) cuyos parquet NO
+    viajan en el bundle (public_bundle_eligible). El catálogo del ZIP se
+    filtra a las capas cuyos archivos están en el manifest, y su
+    `dataset_count` refleja el conteo real (Plan 071). El alias
+    `comunas_enriquecidas` (sin archivo propio, apunta al parquet de
+    `comunas`) se conserva: su `outputs` se reescribe al parquet real del
+    dataset canónico para que el consumidor pueda resolverlo.
+    """
+    import json
+
+    catalog_path = os.path.join(NORMALIZED_DIR, "dataset_catalog.json")
+    with open(catalog_path, encoding="utf-8") as f:
+        catalog = json.load(f)
+
+    manifest_names = {a["path"] for a in artifacts}
+
+    def _has_parquet(dataset_name: str, entry: dict) -> bool:
+        alias_for = entry.get("alias_for")
+        target = alias_for if alias_for else dataset_name
+        return f"data/normalized/{target}.parquet" in manifest_names
+
+    filtered = [
+        entry
+        for entry in catalog.get("datasets", [])
+        if _has_parquet(entry.get("dataset", ""), entry)
+    ]
+    catalog["datasets"] = filtered
+    catalog["dataset_count"] = len(filtered)
+    return json.dumps(catalog, ensure_ascii=False, indent=2) + "\n"
+
+
 def write_publishable_bundle_zip():
     manifest_path = os.path.join(NORMALIZED_DIR, "artifact_manifest.json")
     with open(manifest_path, encoding="utf-8") as f:
@@ -395,6 +430,14 @@ def write_publishable_bundle_zip():
         for artifact in artifacts:
             relative_path = artifact["path"]
             absolute_path = os.path.join(DATA_DIR, os.path.relpath(relative_path, "data"))
+            # El dataset_catalog.json completo declara capas candidate con
+            # outputs que NO viajan en el bundle (Plan 071): dentro del ZIP,
+            # el catálogo se filtra a las capas cuyos archivos SÍ están en el
+            # manifest, para que un consumidor no encuentre capas sin archivo.
+            if relative_path == "data/normalized/dataset_catalog.json":
+                catalog_text = _bundle_filtered_catalog(artifacts)
+                archive.writestr(relative_path, catalog_text)
+                continue
             archive.write(absolute_path, arcname=relative_path)
 
     with zipfile.ZipFile(tmp_path, "r") as archive:

--- a/src/builders/io_utils.py
+++ b/src/builders/io_utils.py
@@ -40,6 +40,16 @@ def compute_sha256(path):
     return hasher.hexdigest()
 
 
+def compute_sha256_bytes(data: bytes) -> str:
+    """SHA-256 de un buffer en memoria (sin tocar disco).
+
+    Usado por el builder del bundle ZIP para describir el catálogo filtrado
+    embebido (Plan 071): sus bytes difieren del archivo en disco, así que el
+    manifest embebido debe declarar el hash del contenido real.
+    """
+    return hashlib.sha256(data).hexdigest()
+
+
 def read_json_if_exists(path):
     if not os.path.exists(path):
         return None

--- a/tests/test_builders_artifacts.py
+++ b/tests/test_builders_artifacts.py
@@ -78,6 +78,28 @@ def _create_test_manifest(normalized_dir: str) -> str:
         _make_artifact_entry("data/normalized/test_metadata.json", "test_dataset", "json")
     )
 
+    # dataset_catalog.json (shared artifact): catálogo REAL con una capa
+    # candidate que tiene outputs pero SIN parquet en el manifest — el caso
+    # que el filtro del ZIP (Plan 071) debe eliminar.
+    catalog = {
+        "generated_at_utc": "2026-07-09T00:00:00+00:00",
+        "dataset_count": 2,
+        "datasets": [
+            {
+                "dataset": "test_dataset",
+                "outputs": {"parquet": "data/normalized/test_data.parquet"},
+            },
+            {
+                "dataset": "test_candidate",
+                "outputs": {"parquet": "data/normalized/test_candidate.parquet"},
+            },
+        ],
+    }
+    catalog_path = os.path.join(normalized_dir, "dataset_catalog.json")
+    with open(catalog_path, "w", encoding="utf-8") as f:
+        json.dump(catalog, f, ensure_ascii=False, indent=2)
+    artifacts.append(_make_artifact_entry("data/normalized/dataset_catalog.json", None, "shared"))
+
     manifest = {
         "generated_at_utc": "2026-07-09T00:00:00+00:00",
         "artifact_count": len(artifacts),
@@ -150,6 +172,44 @@ class TestBundleZip:
                 assert artifact["path"] in namelist, (
                     f"Ruta '{artifact['path']}' del manifiesto no encontrada en ZIP: {namelist}"
                 )
+
+    def test_bundle_zip_catalog_only_declares_included_layers(self):
+        """El dataset_catalog.json del ZIP no declara capas sin su parquet.
+
+        Plan 071: el catálogo completo declara capas candidate con `outputs`
+        (p. ej. perfil_territorial_comunal, consumo_electrico_comunal) cuyos
+        parquet NO viajan en el bundle. El catálogo interno del ZIP debe
+        filtrarse a las capas con archivos presentes, y su dataset_count debe
+        reflejar el conteo real.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized = os.path.join(tmpdir, "normalized")
+            os.makedirs(normalized, exist_ok=True)
+            data_dir = tmpdir
+
+            _create_test_manifest(normalized)
+
+            with (
+                patch("src.builders.artifacts.NORMALIZED_DIR", normalized),
+                patch("src.builders.artifacts.DATA_DIR", data_dir),
+            ):
+                zip_path = write_publishable_bundle_zip()
+
+            with zipfile.ZipFile(zip_path, "r") as zf:
+                names = set(zf.namelist())
+                catalog = json.loads(
+                    zf.read("data/normalized/dataset_catalog.json").decode("utf-8")
+                )
+
+            missing = [
+                entry["dataset"]
+                for entry in catalog["datasets"]
+                if entry.get("outputs")
+                and f"data/normalized/{entry['dataset']}.parquet" not in names
+                and entry.get("dataset") != "comunas_enriquecidas"
+            ]
+            assert not missing, f"Capas del catálogo del ZIP sin parquet: {missing}"
+            assert catalog["dataset_count"] == len(catalog["datasets"])
 
     def test_bundle_zip_missing_artifact_raises_system_exit(self):
         """SystemExit si falta un artefacto declarado en el manifiesto."""

--- a/tests/test_builders_artifacts.py
+++ b/tests/test_builders_artifacts.py
@@ -99,6 +99,10 @@ def _create_test_manifest(normalized_dir: str) -> str:
     with open(catalog_path, "w", encoding="utf-8") as f:
         json.dump(catalog, f, ensure_ascii=False, indent=2)
     artifacts.append(_make_artifact_entry("data/normalized/dataset_catalog.json", None, "shared"))
+    # El artifact_manifest.json también viaja en el ZIP real (shared artifact);
+    # el test lo incluye para verificar la consistencia size/sha256 del
+    # catálogo filtrado embebido (Plan 071).
+    artifacts.append(_make_artifact_entry("data/normalized/artifact_manifest.json", None, "shared"))
 
     manifest = {
         "generated_at_utc": "2026-07-09T00:00:00+00:00",
@@ -200,6 +204,10 @@ class TestBundleZip:
                 catalog = json.loads(
                     zf.read("data/normalized/dataset_catalog.json").decode("utf-8")
                 )
+                embedded_manifest = json.loads(
+                    zf.read("data/normalized/artifact_manifest.json").decode("utf-8")
+                )
+                cat_bytes = zf.read("data/normalized/dataset_catalog.json")
 
             missing = [
                 entry["dataset"]
@@ -210,6 +218,20 @@ class TestBundleZip:
             ]
             assert not missing, f"Capas del catálogo del ZIP sin parquet: {missing}"
             assert catalog["dataset_count"] == len(catalog["datasets"])
+
+            # El manifest embebido debe describir el catálogo filtrado real
+            # (size/sha256 coincidentes) — P1 de la review del Plan 071:
+            # validar el bundle contra su manifest no debe reportar el
+            # catálogo como corrupto.
+            cat_entry = next(
+                a
+                for a in embedded_manifest["artifacts"]
+                if a["path"] == "data/normalized/dataset_catalog.json"
+            )
+            import hashlib
+
+            assert cat_entry["size_bytes"] == len(cat_bytes)
+            assert cat_entry["sha256"] == hashlib.sha256(cat_bytes).hexdigest()
 
     def test_bundle_zip_missing_artifact_raises_system_exit(self):
         """SystemExit si falta un artefacto declarado en el manifiesto."""

--- a/tests/test_builders_artifacts.py
+++ b/tests/test_builders_artifacts.py
@@ -447,7 +447,31 @@ class TestFromNormalFlow:
                     "output_type": "parquet",
                     "format": "parquet",
                 },
+                {
+                    "path": "data/normalized/dataset_catalog.json",
+                    "dataset": None,
+                    "output_type": "shared",
+                    "format": "json",
+                },
+                {
+                    "path": "data/normalized/artifact_manifest.json",
+                    "dataset": None,
+                    "output_type": "shared",
+                    "format": "json",
+                },
             ]
+            catalog = {
+                "generated_at_utc": "2026-07-09T00:00:00+00:00",
+                "dataset_count": 1,
+                "datasets": [
+                    {
+                        "dataset": "regiones",
+                        "outputs": {"parquet": "data/normalized/regiones.parquet"},
+                    }
+                ],
+            }
+            with open(os.path.join(normalized, "dataset_catalog.json"), "w", encoding="utf-8") as f:
+                json.dump(catalog, f, ensure_ascii=False, indent=2)
             manifest = {
                 "generated_at_utc": "2026-07-09T00:00:00+00:00",
                 "artifact_count": len(artifacts),


### PR DESCRIPTION
## Plan 071 — Bug confirmado en el ZIP publicado

El `dataset_catalog.json` interno del bundle declaraba 19 capas con outputs pero el ZIP solo tiene 16 parquet — 3 sin archivo (`comunas_enriquecidas` alias, `perfil_territorial_comunal` y `consumo_electrico_comunal` candidate). Un consumidor que iterara el catálogo del bundle encontraba capas inexistentes.

## Cambios

1. **`artifacts.py`**: `_bundle_filtered_catalog()` genera la variante del catálogo para DENTRO del ZIP — solo capas cuyos parquet están en el manifest (`public_bundle_eligible`); `dataset_count` refleja el conteo real; el alias `comunas_enriquecidas` se conserva (apunta al parquet de `comunas`).
2. **`write_publishable_bundle_zip`**: el catálogo se escribe filtrado (`writestr`) en lugar del archivo completo.
3. **Tests**: manifest sintético con candidate (outputs sin parquet) + test de consistencia catálogo-vs-contenido del ZIP.

## Verificación

- ZIP real: 17 capas, cero capas sin parquet, candidate fuera.
- Suite 867 tests + 1 skip; lint, format, doctor verdes.