### PR TITLE
fix(data_manager): zip-slip guard en _extract_bundle (Plan 072)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **868 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **873 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **873 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **874 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -131,7 +131,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 069 | [Override INE como delivery visible (no enmascarado como backfill)](069-ine-override-delivery-visible.md) | P1 | M | MED | — | DONE (2026-08-12, commit 6ef22fd — delivery visible en extractor + gates; branch advisor/069 sin merge) |
 | 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | DONE (2026-08-12, commit d34462f — registry como fuente de carril; branch advisor/070 sin merge) |
 | 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | DONE (2026-08-12, commit e9d6041 — catálogo filtrado en el ZIP; branch advisor/071 sin merge) |
-| 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | TODO |
+| 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | DONE (2026-08-12, commit a1e50d3 — guard en _extract_bundle; branch advisor/072 sin merge) |
 | 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | TODO |
 | 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | TODO |
 | 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | TODO |

--- a/src/chile_hub/data_manager.py
+++ b/src/chile_hub/data_manager.py
@@ -369,15 +369,14 @@ class ChileHubDataManager:
                         f.write(chunk)
 
     def _extract_bundle(self, bundle_path: Path) -> None:
-        if self.normalized_dir.exists():
-            shutil.rmtree(self.normalized_dir)
+        # Zip-slip guard (Plan 072): el checksum SHA-256 verifica el bundle
+        # contra un .sha256 de la MISMA release de GitHub — no añade un
+        # dominio de confianza distinto. Un miembro con `../` o un symlink
+        # permitiría escritura arbitraria fuera del directorio de caché si
+        # la release se viera comprometida. Se validan TODOS los miembros
+        # ANTES de tocar el cache: un bundle rechazado no debe destruir la
+        # caché verificada previa (P2 de la review del Plan 072).
         with zipfile.ZipFile(bundle_path) as archive:
-            # Zip-slip guard (Plan 072): el checksum SHA-256 verifica el bundle
-            # contra un .sha256 de la MISMA release de GitHub — no añade un
-            # dominio de confianza distinto. Un miembro con `../` o un symlink
-            # permitiría escritura arbitraria fuera del directorio de caché si
-            # la release se viera comprometida. Se validan TODOS los miembros
-            # antes de extraer: solo se aceptan rutas bajo `data/normalized/`.
             for member in archive.infolist():
                 filename = member.filename
                 if not filename or filename == ".":
@@ -396,6 +395,10 @@ class ChileHubDataManager:
                     raise ChileHubDataError(
                         f"Bundle ZIP inválido: miembro symlink no permitido: {filename!r}"
                     )
+        # Validación completa OK: recién aquí se reemplaza el cache verificado.
+        if self.normalized_dir.exists():
+            shutil.rmtree(self.normalized_dir)
+        with zipfile.ZipFile(bundle_path) as archive:
             archive.extractall(self.version_cache_dir)
 
     @staticmethod

--- a/src/chile_hub/data_manager.py
+++ b/src/chile_hub/data_manager.py
@@ -372,6 +372,30 @@ class ChileHubDataManager:
         if self.normalized_dir.exists():
             shutil.rmtree(self.normalized_dir)
         with zipfile.ZipFile(bundle_path) as archive:
+            # Zip-slip guard (Plan 072): el checksum SHA-256 verifica el bundle
+            # contra un .sha256 de la MISMA release de GitHub — no añade un
+            # dominio de confianza distinto. Un miembro con `../` o un symlink
+            # permitiría escritura arbitraria fuera del directorio de caché si
+            # la release se viera comprometida. Se validan TODOS los miembros
+            # antes de extraer: solo se aceptan rutas bajo `data/normalized/`.
+            for member in archive.infolist():
+                filename = member.filename
+                if not filename or filename == ".":
+                    raise ChileHubDataError("Bundle ZIP inválido: miembro con nombre vacío o '.'.")
+                if filename.startswith("/") or "\\" in filename or ".." in filename:
+                    raise ChileHubDataError(
+                        f"Bundle ZIP inválido: miembro con path traversal: {filename!r}"
+                    )
+                if not filename.startswith("data/normalized/"):
+                    raise ChileHubDataError(
+                        f"Bundle ZIP inválido: miembro fuera de data/normalized/: {filename!r}"
+                    )
+                # Detección de symlink: el modo unix (S_IFLNK = 0o120000) se
+                # codifica en los bits altos de external_attr de ZipInfo.
+                if member.external_attr >> 16 & 0o170000 == 0o120000:
+                    raise ChileHubDataError(
+                        f"Bundle ZIP inválido: miembro symlink no permitido: {filename!r}"
+                    )
             archive.extractall(self.version_cache_dir)
 
     @staticmethod

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -252,6 +252,33 @@ class ChileHubDataManagerUnitTests(unittest.TestCase):
             self.assertFalse((Path(tmpdir).parent / "evil.txt").exists())
             self.assertFalse((Path(tmpdir) / "evil.txt").exists())
 
+    def test_extract_rejected_bundle_preserves_existing_cache(self):
+        """Un bundle rechazado NO debe destruir la caché verificada previa.
+
+        P2 de la review del Plan 072: la validación de miembros ocurría
+        DESPUÉS del rmtree del cache — un bundle checksum-válido pero
+        rechazado dejaba al usuario sin sus datos verificados. Ahora la
+        validación es previa: la caché existente se preserva ante rechazo.
+        """
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = self._make_extract_manager(tmpdir)
+            manager.normalized_dir.mkdir(parents=True, exist_ok=True)
+            marker = manager.normalized_dir / "verified.txt"
+            marker.write_text("verified-data")
+
+            bundle_path = manager.version_cache_dir / "evil.zip"
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                zf.writestr("../evil.txt", "pwned")
+
+            with self.assertRaises(ChileHubDataError):
+                manager._extract_bundle(bundle_path)
+
+            # La caché verificada previa sigue intacta.
+            self.assertTrue(marker.exists())
+            self.assertEqual(marker.read_text(), "verified-data")
+
     def test_extract_rejects_out_of_tree_member(self):
         """_extract_bundle() rechaza un miembro fuera de data/normalized/."""
         import zipfile

--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -223,6 +223,96 @@ class ChileHubDataManagerUnitTests(unittest.TestCase):
             if cache_root.exists():
                 shutil.rmtree(str(cache_root))
 
+    def _make_extract_manager(self, tmpdir):
+        """Manager de prueba con rutas bajo un tmpdir (sin tocar cache real)."""
+        manager = ChileHubDataManager(cache_dir=tmpdir, data_version="v0.0.0-test")
+        manager.version_cache_dir.mkdir(parents=True, exist_ok=True)
+        return manager
+
+    def test_extract_rejects_zip_slip_member(self):
+        """_extract_bundle() rechaza un miembro con `../` (zip-slip, Plan 072).
+
+        El checksum SHA-256 verifica el bundle contra un .sha256 de la MISMA
+        release de GitHub — no añade un dominio de confianza distinto. Un
+        miembro con path traversal escribiría fuera del directorio de caché
+        si la release se viera comprometida.
+        """
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = self._make_extract_manager(tmpdir)
+            bundle_path = manager.version_cache_dir / "evil.zip"
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                zf.writestr("data/normalized/ok.txt", "ok")
+                zf.writestr("../evil.txt", "pwned")
+
+            with self.assertRaises(ChileHubDataError) as ctx:
+                manager._extract_bundle(bundle_path)
+            self.assertIn("path traversal", str(ctx.exception))
+            self.assertFalse((Path(tmpdir).parent / "evil.txt").exists())
+            self.assertFalse((Path(tmpdir) / "evil.txt").exists())
+
+    def test_extract_rejects_out_of_tree_member(self):
+        """_extract_bundle() rechaza un miembro fuera de data/normalized/."""
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = self._make_extract_manager(tmpdir)
+            bundle_path = manager.version_cache_dir / "oob.zip"
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                zf.writestr("data/other/evil.txt", "pwned")
+
+            with self.assertRaises(ChileHubDataError) as ctx:
+                manager._extract_bundle(bundle_path)
+            self.assertIn("fuera de data/normalized/", str(ctx.exception))
+
+    def test_extract_rejects_absolute_path_member(self):
+        """_extract_bundle() rechaza un miembro con path absoluto."""
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = self._make_extract_manager(tmpdir)
+            bundle_path = manager.version_cache_dir / "abs.zip"
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                zf.writestr("/tmp/evil.txt", "pwned")
+
+            with self.assertRaises(ChileHubDataError) as ctx:
+                manager._extract_bundle(bundle_path)
+            self.assertIn("path traversal", str(ctx.exception))
+
+    def test_extract_accepts_legitimate_bundle(self):
+        """_extract_bundle() acepta un bundle con entradas bajo data/normalized/."""
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = self._make_extract_manager(tmpdir)
+            bundle_path = manager.version_cache_dir / "ok.zip"
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                zf.writestr("data/normalized/comunas.parquet", b"fake-parquet")
+                zf.writestr("data/normalized/dataset_catalog.json", "{}")
+
+            manager._extract_bundle(bundle_path)
+            self.assertTrue((manager.normalized_dir / "comunas.parquet").exists())
+            self.assertTrue((manager.normalized_dir / "dataset_catalog.json").exists())
+
+    def test_extract_rejects_symlink_member(self):
+        """_extract_bundle() rechaza un miembro symlink (zip-slip, Plan 072)."""
+        import stat
+        import zipfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = self._make_extract_manager(tmpdir)
+            bundle_path = manager.version_cache_dir / "symlink.zip"
+            with zipfile.ZipFile(bundle_path, "w") as zf:
+                info = zipfile.ZipInfo("data/normalized/evil-link")
+                info.create_system = 3  # unix
+                info.external_attr = stat.S_IFLNK << 16 | 0o777
+                zf.writestr(info, "/etc/passwd")
+
+            with self.assertRaises(ChileHubDataError) as ctx:
+                manager._extract_bundle(bundle_path)
+            self.assertIn("symlink", str(ctx.exception))
+
 
 class GeoCacheIntegrityTests(unittest.TestCase):
     """Contrato de distribución/caché de la geometría (Plan 065, ADR-012).


### PR DESCRIPTION
## Plan 072 — Seguridad del consumidor

`_extract_bundle` hacía `archive.extractall()` sobre el bundle descargado sin inspeccionar `namelist()`. El checksum SHA-256 verifica el bundle contra un `.sha256` de la **misma** release de GitHub — no añade un dominio de confianza distinto. Si la release se viera comprometida (supply chain), un miembro con `../` o un symlink permitiría escritura arbitraria fuera del directorio de caché en la máquina de cada consumidor que corre `chile-hub cache update`.

## Cambios

1. **`data_manager.py`**: `_extract_bundle` valida TODOS los miembros antes de extraer:
   - ruta bajo `data/normalized/` (obligatorio)
   - sin `..`, `\\` ni path absoluto (`/`)
   - sin symlink (detección vía `external_attr`, modo unix `S_IFLNK`)
   - error `ChileHubDataError` con el nombre del miembro
2. **Tests** (5 nuevos en `test_data_manager.py`): zip-slip, fuera-de-árbol, path absoluto, symlink, bundle legítimo.

## Verificación

- El bundle real pasa el guard (56 miembros, todos bajo `data/normalized/`).
- Suite 872 tests + 1 skip; lint, format, doctor verdes.