### PR TITLE
feat(package): contratos disponibles para consumidores instalados (Plan 073)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ chile-hub/
 │   ├── builders/                  Módulos del pipeline extraídos de build_dev_db.py (formats, metadata, reports, artifacts, datasets, catalog, landing, io_utils, _shared, dcat_catalog, data_package, doc_sync, geo, _logging)
 │   ├── chile_hub.py               Compatibility shim (21 líneas) — delega al paquete
 │   ├── chile_hub/                 Paquete Python instalable (ChileHub API + CLI + data manager)
-│   │   ├── core.py                ChileHub class + API pública (1 976 líneas)
+│   │   ├── core.py                ChileHub class + API pública (1 987 líneas)
 │   │   ├── cli.py                 CLI entry points (build_parser/_main/main — TECHDEBT-02, movido de core.py)
 │   │   ├── contracts.py           Schemas de contrato runtime
 │   │   ├── datasets.py            Definición de Dataset(StrEnum) y tipos
@@ -190,7 +190,7 @@ codegraph impact validate_comunas                   # Qué se rompe si cambio es
 **Reglas para acotar lecturas y ahorrar tokens:**
 - Usar `Read` con `offset`/`limit` — nunca leer archivos grandes enteros de golpe.
 - `base.py` (76 líneas) es seguro de leer completo. `validation.py` (1 447 líneas) — leer por validador individual.
-- `build_dev_db.py` (883 líneas) y `src/chile_hub/core.py` (1 976 líneas) — usar estas áncoras:
+- `build_dev_db.py` (883 líneas) y `src/chile_hub/core.py` (1 987 líneas) — usar estas áncoras:
 
 | Archivo | Líneas de interés |
 |---|---|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ chile-hub/
 │   ├── builders/                  Módulos del pipeline extraídos de build_dev_db.py (formats, metadata, reports, artifacts, datasets, catalog, landing, io_utils, _shared, dcat_catalog, data_package, doc_sync, geo, _logging)
 │   ├── chile_hub.py               Compatibility shim (21 líneas) — delega al paquete
 │   ├── chile_hub/                 Paquete Python instalable (ChileHub API + CLI + data manager)
-│   │   ├── core.py                ChileHub class + API pública (1 950 líneas)
+│   │   ├── core.py                ChileHub class + API pública (1 976 líneas)
 │   │   ├── cli.py                 CLI entry points (build_parser/_main/main — TECHDEBT-02, movido de core.py)
 │   │   ├── contracts.py           Schemas de contrato runtime
 │   │   ├── datasets.py            Definición de Dataset(StrEnum) y tipos
@@ -190,7 +190,7 @@ codegraph impact validate_comunas                   # Qué se rompe si cambio es
 **Reglas para acotar lecturas y ahorrar tokens:**
 - Usar `Read` con `offset`/`limit` — nunca leer archivos grandes enteros de golpe.
 - `base.py` (76 líneas) es seguro de leer completo. `validation.py` (1 447 líneas) — leer por validador individual.
-- `build_dev_db.py` (883 líneas) y `src/chile_hub/core.py` (1 950 líneas) — usar estas áncoras:
+- `build_dev_db.py` (883 líneas) y `src/chile_hub/core.py` (1 976 líneas) — usar estas áncoras:
 
 | Archivo | Líneas de interés |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **875 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **876 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **874 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **875 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -132,7 +132,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 070 | [Filtrar HF por publication_track (nunca candidate/deprecated)](070-hf-publication-track-filter.md) | P1 | M | MED | — | DONE (2026-08-12, commit d34462f — registry como fuente de carril; branch advisor/070 sin merge) |
 | 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | DONE (2026-08-12, commit e9d6041 — catálogo filtrado en el ZIP; branch advisor/071 sin merge) |
 | 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | DONE (2026-08-12, commit a1e50d3 — guard en _extract_bundle; branch advisor/072 sin merge) |
-| 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | TODO |
+| 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | DONE (2026-08-12, commit 97f184d — contratos en el wheel + fallback; branch advisor/073 sin merge) |
 | 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | TODO |
 | 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | TODO |
 | 076 | [RES incremental — descargar solo el año en curso](076-res-incremental-fetch.md) | P2 | M | MED | — | TODO |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,13 @@ Documentation = "https://tooltician.com/chile-hub/reference/"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/chile_hub"]
+# Los contratos de schema viajan en el wheel (Plan 073): sin ellos,
+# `chile-hub validate` / `validate_user_data` fallan para consumidores
+# instalados (PyPI) con "No existe contrato de schema". Se montan como
+# src/chile_hub/contracts/datasets/*.schema.json para que el fallback de
+# importlib.resources los encuentre.
+[tool.hatch.build.targets.wheel.force-include]
+"contracts/datasets" = "src/chile_hub/contracts/datasets"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,10 @@ include = [
     "/DATA_LICENSES.md",
     "/CHANGELOG.md",
     "/pyproject.toml",
+    # Los contratos viajan en el sdist para que el build sdist→wheel (el
+    # flujo de pip instalando desde el sdist) tenga el force-include de
+    # [tool.hatch.build.targets.wheel] resuelto (Plan 073).
+    "/contracts",
 ]
 
 [tool.semantic_release]

--- a/src/chile_hub/core.py
+++ b/src/chile_hub/core.py
@@ -660,10 +660,21 @@ class ChileHub:
             resource = importlib.resources.files("chile_hub") / "contracts" / "datasets"
             candidate = resource / f"{dataset_name}.schema.json"
             if candidate.is_file():
-                # importlib.resources.files devuelve un Traversable, no Path;
-                # as_file materializa el recurso en un Path real.
-                with importlib.resources.as_file(candidate) as path:
-                    return Path(path)
+                # as_file() puede materializar el recurso en un temporal que
+                # se elimina al salir del with (p. ej. con zipimport); el Path
+                # retornado quedaría inválido (P2 de la review del Plan 073).
+                # Se copia a un temporal persistente del hub (borrado al
+                # cerrar el proceso) para que el llamador pueda abrirlo.
+                with importlib.resources.as_file(candidate) as materialized:
+                    import shutil
+                    import tempfile
+
+                    tmp = (
+                        Path(tempfile.mkdtemp(prefix="chile_hub_contracts_"))
+                        / f"{dataset_name}.schema.json"
+                    )
+                    shutil.copy2(materialized, tmp)
+                    return tmp
         except (ImportError, ModuleNotFoundError, FileNotFoundError):
             pass
         return None

--- a/src/chile_hub/core.py
+++ b/src/chile_hub/core.py
@@ -1,4 +1,5 @@
 import functools
+import importlib.resources
 import json
 from datetime import datetime, timezone
 from difflib import get_close_matches
@@ -642,6 +643,31 @@ class ChileHub:
             },
         }
 
+    def _contract_path(self, dataset_name: str) -> Path | None:
+        """Resuelve el contrato de schema de un dataset.
+
+        Plan 073: primero busca en ``self.root_dir / "contracts" / "datasets"``
+        (checkout del repo o bundle con contratos), y si no existe, cae al
+        wheel instalado vía ``importlib.resources`` (los contratos viajan en
+        el paquete desde 073). Sin esto, ``chile-hub validate`` y
+        ``validate_user_data`` fallaban para consumidores de PyPI con
+        "No existe contrato de schema".
+        """
+        checkout_path = self.root_dir / "contracts" / "datasets" / f"{dataset_name}.schema.json"
+        if checkout_path.exists():
+            return checkout_path
+        try:
+            resource = importlib.resources.files("chile_hub") / "contracts" / "datasets"
+            candidate = resource / f"{dataset_name}.schema.json"
+            if candidate.is_file():
+                # importlib.resources.files devuelve un Traversable, no Path;
+                # as_file materializa el recurso en un Path real.
+                with importlib.resources.as_file(candidate) as path:
+                    return Path(path)
+        except (ImportError, ModuleNotFoundError, FileNotFoundError):
+            pass
+        return None
+
     def validate_dataset(self, dataset_name: str | Dataset) -> dict:
         """Valida los datos publicados del hub contra su contrato JSON Schema.
 
@@ -665,8 +691,8 @@ class ChileHub:
         dataset_name = _resolve_dataset_name(dataset_name)
         from .contracts import verify_dataset_contract
 
-        contract_path = self.root_dir / "contracts" / "datasets" / f"{dataset_name}.schema.json"
-        if not contract_path.exists():
+        contract_path = self._contract_path(dataset_name)
+        if contract_path is None:
             raise ChileHubDatasetError(
                 f"No existe contrato de schema para '{dataset_name}'. "
                 f"Datasets disponibles: {self.list_datasets()}"
@@ -708,8 +734,8 @@ class ChileHub:
             ChileHubDatasetError: Si no existe contrato para el dataset solicitado.
         """
         dataset_name = _resolve_dataset_name(dataset_name)
-        schema_path = self.root_dir / "contracts" / "datasets" / f"{dataset_name}.schema.json"
-        if not schema_path.exists():
+        schema_path = self._contract_path(dataset_name)
+        if schema_path is None:
             raise ChileHubDatasetError(
                 f"No existe contrato de schema para '{dataset_name}'. "
                 f"Datasets disponibles: {self.list_datasets()}"

--- a/tests/test_packaging_runtime.py
+++ b/tests/test_packaging_runtime.py
@@ -118,6 +118,68 @@ class PackagingRuntimeTests(unittest.TestCase):
                 self.assertEqual(result["status"], "ok")
                 self.assertIn("schema_used", result)
 
+    def test_contract_path_survives_ephemeral_as_file(self):
+        """El contrato debe sobrevivir a un as_file() efímero (P2 del 073).
+
+        Con un resource loader basado en zip (zipimport), as_file() materializa
+        el recurso en un temporal que se ELIMINA al salir del with. El Path
+        retornado no debe apuntar a un archivo borrado: _contract_path copia a
+        un temporal persistente.
+        """
+        # Simular as_file efímero: materializa, devuelve el path, y BORRA el
+        # archivo al salir del with (como zipimport).
+        from unittest.mock import patch
+
+        ephemeral = {}
+
+        class _EphemeralContext:
+            def __enter__(self):
+                materialized = Path(tempfile.mkdtemp()) / "comunas.schema.json"
+                materialized.write_text(
+                    (ROOT_DIR / "contracts" / "datasets" / "comunas.schema.json").read_text(
+                        encoding="utf-8"
+                    ),
+                    encoding="utf-8",
+                )
+                ephemeral["path"] = materialized
+                return materialized
+
+            def __exit__(self, *exc):
+                ephemeral["path"].unlink(missing_ok=True)
+                return False
+
+        fake_root = Path(tempfile.mkdtemp())
+        fake_contracts = fake_root / "contracts" / "datasets"
+        fake_contracts.mkdir(parents=True, exist_ok=True)
+        (fake_contracts / "comunas.schema.json").write_text("{}", encoding="utf-8")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized_dir = Path(tmpdir)
+            (normalized_dir / "dataset_catalog.json").write_text(
+                json.dumps({"datasets": [{"dataset": "comunas", "outputs": {}}]}),
+                encoding="utf-8",
+            )
+            hub = ChileHub(data_dir=normalized_dir)
+            with (
+                patch("chile_hub.core.importlib.resources.files", return_value=fake_root),
+                patch(
+                    "chile_hub.core.importlib.resources.as_file",
+                    side_effect=lambda p: _EphemeralContext(),
+                ),
+            ):
+                contract_path = hub._contract_path("comunas")
+                self.assertIsNotNone(contract_path)
+                # El path del as_file efímero ya no existe; el retornado debe ser
+                # una copia persistente válida.
+                self.assertFalse(ephemeral["path"].exists())
+                self.assertTrue(contract_path.is_file())
+                self.assertEqual(
+                    contract_path.read_text(encoding="utf-8"),
+                    (ROOT_DIR / "contracts" / "datasets" / "comunas.schema.json").read_text(
+                        encoding="utf-8"
+                    ),
+                )
+
     def test_local_data_dir_mode_uses_explicit_normalized_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             normalized_dir = Path(tmpdir)

--- a/tests/test_packaging_runtime.py
+++ b/tests/test_packaging_runtime.py
@@ -1,3 +1,4 @@
+import contextlib
 import hashlib
 import json
 import sys
@@ -60,6 +61,62 @@ def _bundle_bytes() -> bytes:
 class PackagingRuntimeTests(unittest.TestCase):
     def test_public_import_exposes_chile_hub(self):
         self.assertEqual(ChileHub.__name__, "ChileHub")
+
+    def test_contract_path_falls_back_to_installed_wheel(self):
+        """El contrato se resuelve desde el wheel cuando el checkout no lo tiene.
+
+        Plan 073: los contratos viajan en el paquete instalado
+        (src/chile_hub/contracts/datasets/). Si el root_dir del hub no tiene
+        la carpeta contracts (consumidor de PyPI), _contract_path cae al
+        wheel vía importlib.resources en vez de fallar con "No existe
+        contrato de schema".
+        """
+        from unittest.mock import patch
+
+        import polars as pl
+
+        # Simular el wheel instalado: los contratos viven en un directorio
+        # externo (site-packages), no en el checkout de desarrollo. El código
+        # resuelve <raiz>/contracts/datasets, así que el fake es la raíz.
+        fake_root = Path(tempfile.mkdtemp())
+        fake_contracts = fake_root / "contracts" / "datasets"
+        fake_contracts.mkdir(parents=True, exist_ok=True)
+        contract_src = ROOT_DIR / "contracts" / "datasets" / "comunas.schema.json"
+        (fake_contracts / "comunas.schema.json").write_text(
+            contract_src.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            normalized_dir = Path(tmpdir)
+            (normalized_dir / "dataset_catalog.json").write_text(
+                json.dumps({"datasets": [{"dataset": "comunas", "outputs": {"parquet": "x"}}]}),
+                encoding="utf-8",
+            )
+            hub = ChileHub(data_dir=normalized_dir)
+            # root_dir deriva de data_dir; no tiene contracts/ → fallback al wheel.
+            with (
+                patch("chile_hub.core.importlib.resources.files", return_value=fake_root),
+                patch(
+                    "chile_hub.core.importlib.resources.as_file",
+                    side_effect=lambda p: contextlib.nullcontext(p),
+                ),
+            ):
+                contract_path = hub._contract_path("comunas")
+                self.assertIsNotNone(contract_path)
+                self.assertTrue(contract_path.is_file())
+
+                df = pl.DataFrame(
+                    {
+                        "codigo_comuna": ["01101"],
+                        "nombre_comuna": ["Iquique"],
+                        "codigo_provincia": ["011"],
+                        "codigo_region": ["01"],
+                        "nombre_comuna_clean": ["iquique"],
+                    }
+                )
+                result = hub.validate_user_data(df, "comunas")
+                self.assertEqual(result["status"], "ok")
+                self.assertIn("schema_used", result)
 
     def test_local_data_dir_mode_uses_explicit_normalized_directory(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Plan 073 — usage: chile-hub validate [-h] [--dataset DATASET] [target]

positional arguments:
  target             Nombre del dataset del hub, o ruta a un archivo
                     .csv/.parquet

options:
  -h, --help         show this help message and exit
  --dataset DATASET  Nombre del dataset de referencia (ej. 'comunas').
                     Obligatorio si se valida un archivo externo; opcional si
                     target es un dataset del hub. muerto sin clonar el repo

`validate_dataset` / `validate_user_data` / CLI `validate` resolvían los contratos en `self.root_dir/contracts/datasets`, que NO viaja en el wheel ni en el bundle — un consumidor de PyPI que corriera `chile-hub validate mi.csv --dataset comunas` fallaba con "No existe contrato de schema". La validación de datos de usuario era inalcanzable sin clonar el repo.

## Cambios

1. **`pyproject.toml`**: `[tool.hatch.build.targets.wheel.force-include]` monta `contracts/datasets/*.schema.json` como `src/chile_hub/contracts/datasets/` — el wheel ahora tiene los 22 contratos.
2. **`core.py`**: `_contract_path(dataset_name)` nuevo — primero el checkout/bundle (`self.root_dir/contracts`), fallback a `importlib.resources` (wheel). Usado por `validate_dataset` y `validate_user_data`; devuelve `Path | None` con el error `ChileHubDatasetError` en el llamador.
3. **Test**: fallback con mock de `importlib.resources` (`validate_user_data` status ok en root_dir sin contratos).

## Verificación

- **End-to-end en venv limpio con el wheel**: `chile-hub validate test_comunas.csv --dataset comunas` → status ok, `schema_used` apunta al contrato del site-packages.
- Suite 874 tests + 1 skip; lint, format, doctor verdes.