### PR TITLE
fix(validation): el punto más reciente ≤0 se evalúa con detector de nivel (Plan 074)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ chile-hub/
 │   │   ├── sinim_finanzas_live_extractor.py              Finanzas municipales — scraper real; corre en `monthly-scrape.yml`
 │   │   └── subdere_extractor.py                          DPA: regiones/provincias/comunas/comunas_enriquecidas (BCN ArcGIS) → data/staging/
 <!-- END_AGENTS_EXTRACTOR_LIST -->
-│   ├── validation.py              Todas las funciones validate_*() — módulo independiente (1 447 líneas)
+│   ├── validation.py              Todas las funciones validate_*() — módulo independiente (1 490 líneas)
 │   ├── build_dev_db.py            Orquestador (883 líneas): main() + fases (_load_inputs, _compute_validations, _write_data_artifacts, _generate_reports)
 │   ├── builders/                  Módulos del pipeline extraídos de build_dev_db.py (formats, metadata, reports, artifacts, datasets, catalog, landing, io_utils, _shared, dcat_catalog, data_package, doc_sync, geo, _logging)
 │   ├── chile_hub.py               Compatibility shim (21 líneas) — delega al paquete
@@ -189,7 +189,7 @@ codegraph impact validate_comunas                   # Qué se rompe si cambio es
 
 **Reglas para acotar lecturas y ahorrar tokens:**
 - Usar `Read` con `offset`/`limit` — nunca leer archivos grandes enteros de golpe.
-- `base.py` (76 líneas) es seguro de leer completo. `validation.py` (1 447 líneas) — leer por validador individual.
+- `base.py` (76 líneas) es seguro de leer completo. `validation.py` (1 490 líneas) — leer por validador individual.
 - `build_dev_db.py` (883 líneas) y `src/chile_hub/core.py` (1 987 líneas) — usar estas áncoras:
 
 | Archivo | Líneas de interés |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ chile-hub/
 │   │   ├── sinim_finanzas_live_extractor.py              Finanzas municipales — scraper real; corre en `monthly-scrape.yml`
 │   │   └── subdere_extractor.py                          DPA: regiones/provincias/comunas/comunas_enriquecidas (BCN ArcGIS) → data/staging/
 <!-- END_AGENTS_EXTRACTOR_LIST -->
-│   ├── validation.py              Todas las funciones validate_*() — módulo independiente (1 490 líneas)
+│   ├── validation.py              Todas las funciones validate_*() — módulo independiente (1 505 líneas)
 │   ├── build_dev_db.py            Orquestador (883 líneas): main() + fases (_load_inputs, _compute_validations, _write_data_artifacts, _generate_reports)
 │   ├── builders/                  Módulos del pipeline extraídos de build_dev_db.py (formats, metadata, reports, artifacts, datasets, catalog, landing, io_utils, _shared, dcat_catalog, data_package, doc_sync, geo, _logging)
 │   ├── chile_hub.py               Compatibility shim (21 líneas) — delega al paquete
@@ -189,7 +189,7 @@ codegraph impact validate_comunas                   # Qué se rompe si cambio es
 
 **Reglas para acotar lecturas y ahorrar tokens:**
 - Usar `Read` con `offset`/`limit` — nunca leer archivos grandes enteros de golpe.
-- `base.py` (76 líneas) es seguro de leer completo. `validation.py` (1 490 líneas) — leer por validador individual.
+- `base.py` (76 líneas) es seguro de leer completo. `validation.py` (1 505 líneas) — leer por validador individual.
 - `build_dev_db.py` (883 líneas) y `src/chile_hub/core.py` (1 987 líneas) — usar estas áncoras:
 
 | Archivo | Líneas de interés |

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **876 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **879 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **879 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **881 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -133,7 +133,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 071 | [El catálogo del bundle ZIP solo declara capas realmente incluidas](071-bundle-catalog-consistency.md) | P1 | M | MED | coordina 070 | DONE (2026-08-12, commit e9d6041 — catálogo filtrado en el ZIP; branch advisor/071 sin merge) |
 | 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | DONE (2026-08-12, commit a1e50d3 — guard en _extract_bundle; branch advisor/072 sin merge) |
 | 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | DONE (2026-08-12, commit 97f184d — contratos en el wheel + fallback; branch advisor/073 sin merge) |
-| 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | TODO |
+| 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | DONE (2026-08-12, commit 1b95c1c — detector de nivel para punto ≤0; branch advisor/074 sin merge) |
 | 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | TODO |
 | 076 | [RES incremental — descargar solo el año en curso](076-res-incremental-fetch.md) | P2 | M | MED | — | TODO |
 | 077 | [Caracterizar build_dev_db.py (cobertura 21% → ≥60%)](077-characterize-build-dev-db.md) | P2 | L | MED | — | TODO |

--- a/src/validation.py
+++ b/src/validation.py
@@ -412,21 +412,36 @@ def detect_series_anomalies(
                 continue
             median_level = statistics.median(levels)
             mad_level = statistics.median([abs(v - median_level) for v in levels])
+
             if mad_level == 0:
-                continue
-
-            z_score = 0.6745 * (last_value - median_level) / mad_level
-            if abs(z_score) <= z_threshold:
-                continue
-
-            low = median_level - z_threshold * mad_level / 0.6745
-            high = median_level + z_threshold * mad_level / 0.6745
-            motivo = (
-                f"Salto atípico en '{key}' el {dates[-1]}: valor {last_value} "
-                f"vs. mediana de niveles previos {median_level:.4f} "
-                f"(MAD={mad_level:.4f}, z={z_score:.2f}, umbral={z_threshold}). "
-                f"Rango esperado sin señal: [{round(low, 4)}, {round(high, 4)}]."
-            )
+                # Niveles previos constantes: el MAD no da base para z-score,
+                # pero un último valor distinto de la mediana ES una ruptura
+                # obvia (P2 de la review del Plan 074). Se reporta con z-score
+                # infinito y motivo de ruptura de serie constante. Ej.:
+                # [100, 100, 100, 100, 100, 0] — el 0 es claramente anómalo.
+                if last_value == median_level:
+                    continue
+                low = min(levels)
+                high = max(levels)
+                motivo = (
+                    f"Salto atípico en '{key}' el {dates[-1]}: valor {last_value} "
+                    f"vs. serie de niveles previos constante en {median_level:.4f} "
+                    f"(MAD=0, ruptura de serie constante, umbral={z_threshold}). "
+                    f"Rango esperado sin señal: [{round(low, 4)}, {round(high, 4)}]."
+                )
+                z_score = None  # MAD=0: sin base de z-score; la ruptura es obvia
+            else:
+                z_score = 0.6745 * (last_value - median_level) / mad_level
+                if abs(z_score) <= z_threshold:
+                    continue
+                low = median_level - z_threshold * mad_level / 0.6745
+                high = median_level + z_threshold * mad_level / 0.6745
+                motivo = (
+                    f"Salto atípico en '{key}' el {dates[-1]}: valor {last_value} "
+                    f"vs. mediana de niveles previos {median_level:.4f} "
+                    f"(MAD={mad_level:.4f}, z={z_score:.2f}, umbral={z_threshold}). "
+                    f"Rango esperado sin señal: [{round(low, 4)}, {round(high, 4)}]."
+                )
 
         anomalies.append(
             {
@@ -434,7 +449,7 @@ def detect_series_anomalies(
                 "fecha": dates[-1],
                 "valor": last_value,
                 "esperado_rango": [round(low, 4), round(high, 4)],
-                "z_score": round(z_score, 2),
+                "z_score": round(z_score, 2) if z_score is not None else None,
                 "motivo": motivo,
             }
         )

--- a/src/validation.py
+++ b/src/validation.py
@@ -362,37 +362,80 @@ def detect_series_anomalies(
                 continue
             log_returns.append(math.log(curr_value / prev_value))
 
-        if len(log_returns) < min_history + 1:
-            continue  # no hay suficiente histórico de referencia + el punto a evaluar
+        last_value = values[-1]
+        if len(values) < 2:
+            continue  # una sola observación no permite evaluar un par
+        penultimate_value = values[-2]
 
-        reference = log_returns[:-1]
-        last_return = log_returns[-1]
-        median_ref = statistics.median(reference)
-        mad = statistics.median([abs(r - median_ref) for r in reference])
-        if mad == 0:
-            continue  # serie perfectamente constante en el histórico de referencia; sin base para z-score
+        if (
+            penultimate_value is not None
+            and last_value is not None
+            and penultimate_value > 0
+            and last_value > 0
+        ):
+            # Último par cronológico log-evaluable: flujo actual. log_returns[-1]
+            # ES ese par (se procesa en orden), así que la calibración del
+            # Plan 054 (z_threshold=4.0, cero falsos positivos en 506 registros)
+            # queda intacta.
+            if len(log_returns) < min_history + 1:
+                continue  # no hay suficiente histórico de referencia + el punto a evaluar
 
-        z_score = 0.6745 * (last_return - median_ref) / mad
-        if abs(z_score) <= z_threshold:
-            continue
+            reference = log_returns[:-1]
+            last_return = log_returns[-1]
+            median_ref = statistics.median(reference)
+            mad = statistics.median([abs(r - median_ref) for r in reference])
+            if mad == 0:
+                continue  # serie perfectamente constante; sin base para z-score
 
-        prev_value = values[-2]
-        low = prev_value * math.exp(median_ref - z_threshold * mad / 0.6745)
-        high = prev_value * math.exp(median_ref + z_threshold * mad / 0.6745)
+            z_score = 0.6745 * (last_return - median_ref) / mad
+            if abs(z_score) <= z_threshold:
+                continue
+
+            prev_value = penultimate_value
+            low = prev_value * math.exp(median_ref - z_threshold * mad / 0.6745)
+            high = prev_value * math.exp(median_ref + z_threshold * mad / 0.6745)
+            motivo = (
+                f"Salto atípico en '{key}' el {dates[-1]}: valor {last_value} "
+                f"implica un log-retorno diario de {last_return:.4f} vs. mediana "
+                f"histórica de referencia {median_ref:.4f} (MAD={mad:.4f}, "
+                f"z={z_score:.2f}, umbral={z_threshold}). Rango esperado sin "
+                f"señal: [{round(low, 4)}, {round(high, 4)}]."
+            )
+        else:
+            # Último par NO log-evaluable (valor ≤ 0, común en la variación
+            # mensual del IPC): detector de nivel sobre los valores previos.
+            # Plan 074: antes se evaluaba el último par ADMITIDO (viejo) pero
+            # se reportaba con la fecha/valor del punto nuevo — señal mal
+            # atribuida, justo el guard del valor scrapeado del INE.
+            levels = [v for v in values[:-1] if v is not None]
+            if len(levels) < min_history + 1:
+                continue
+            median_level = statistics.median(levels)
+            mad_level = statistics.median([abs(v - median_level) for v in levels])
+            if mad_level == 0:
+                continue
+
+            z_score = 0.6745 * (last_value - median_level) / mad_level
+            if abs(z_score) <= z_threshold:
+                continue
+
+            low = median_level - z_threshold * mad_level / 0.6745
+            high = median_level + z_threshold * mad_level / 0.6745
+            motivo = (
+                f"Salto atípico en '{key}' el {dates[-1]}: valor {last_value} "
+                f"vs. mediana de niveles previos {median_level:.4f} "
+                f"(MAD={mad_level:.4f}, z={z_score:.2f}, umbral={z_threshold}). "
+                f"Rango esperado sin señal: [{round(low, 4)}, {round(high, 4)}]."
+            )
+
         anomalies.append(
             {
                 "codigo_indicador": key,
                 "fecha": dates[-1],
-                "valor": values[-1],
+                "valor": last_value,
                 "esperado_rango": [round(low, 4), round(high, 4)],
                 "z_score": round(z_score, 2),
-                "motivo": (
-                    f"Salto atípico en '{key}' el {dates[-1]}: valor {values[-1]} "
-                    f"implica un log-retorno diario de {last_return:.4f} vs. mediana "
-                    f"histórica de referencia {median_ref:.4f} (MAD={mad:.4f}, "
-                    f"z={z_score:.2f}, umbral={z_threshold}). Rango esperado sin "
-                    f"señal: [{round(low, 4)}, {round(high, 4)}]."
-                ),
+                "motivo": motivo,
             }
         )
     return anomalies

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -487,6 +487,40 @@ class DetectSeriesAnomaliesTests(unittest.TestCase):
         anomalies = detect_series_anomalies(df)
         self.assertEqual(anomalies, [], f"falsos positivos inesperados: {anomalies}")
 
+    def test_last_point_negative_value_attributed_to_correct_date(self):
+        """El último punto negativo se evalúa con su propia fecha (Plan 074).
+
+        Antes: cuando el último valor era ≤ 0 (común en la variación mensual
+        del IPC), el par log-retorno se saltaba y se evaluaba un par VIEJO
+        pero se reportaba con la fecha/valor del punto nuevo — señal mal
+        atribuida, justo el guard del valor scrapeado del INE. Ahora el punto
+        negativo se evalúa con el detector de nivel y su fecha real.
+        """
+        # Serie con salto final a negativo: el último par no es log-evaluable.
+        values = [0.3, 0.2, 0.4, 0.3, 0.5, -2.0]
+        df = self._make_series(values, code="ipc")
+        anomalies = detect_series_anomalies(df, z_threshold=4.0, min_history=4)
+        self.assertEqual(len(anomalies), 1, f"esperada 1 anomalía, got: {anomalies}")
+        self.assertEqual(anomalies[0]["fecha"], "2024-01-06")
+        self.assertEqual(anomalies[0]["valor"], -2.0)
+        self.assertEqual(anomalies[0]["codigo_indicador"], "ipc")
+        self.assertIn("niveles previos", anomalies[0]["motivo"])
+
+    def test_negative_values_without_real_jump_not_flagged(self):
+        """Valores negativos sin salto real no deben disparar señal (Plan 074)."""
+        # Variación mensual del IPC realista: valores pequeños, algunos negativos.
+        values = [0.3, -0.2, 0.1, 0.4, -0.1, 0.2, -0.3, 0.1]
+        df = self._make_series(values, code="ipc")
+        anomalies = detect_series_anomalies(df, z_threshold=4.0, min_history=4)
+        self.assertEqual(anomalies, [])
+
+    def test_negative_last_point_without_history_not_flagged(self):
+        """Con poco histórico previo, un punto negativo no dispara señal."""
+        values = [0.3, 0.2, -2.0]
+        df = self._make_series(values, code="ipc")
+        anomalies = detect_series_anomalies(df, z_threshold=4.0, min_history=4)
+        self.assertEqual(anomalies, [])
+
 
 # ── validate_distritos_electorales ─────────────────────────────────────────────
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -521,6 +521,30 @@ class DetectSeriesAnomaliesTests(unittest.TestCase):
         anomalies = detect_series_anomalies(df, z_threshold=4.0, min_history=4)
         self.assertEqual(anomalies, [])
 
+    def test_constant_levels_with_break_at_zero_is_flagged(self):
+        """Niveles previos constantes + último valor distinto = ruptura obvia.
+
+        P2 de la review del Plan 074: con MAD=0 el z-score no tiene base,
+        pero un último valor que rompe una serie constante (p. ej. 0 tras
+        cinco 100) es claramente anómalo — se reporta con motivo de ruptura
+        de serie constante. `valor=0` es schema-válido, así que sin esta
+        señal el dato malformado pasaría al gate de publicación.
+        """
+        values = [100.0, 100.0, 100.0, 100.0, 100.0, 0.0]
+        df = self._make_series(values, code="ipc")
+        anomalies = detect_series_anomalies(df, z_threshold=4.0, min_history=4)
+        self.assertEqual(len(anomalies), 1)
+        self.assertEqual(anomalies[0]["valor"], 0.0)
+        self.assertEqual(anomalies[0]["fecha"], "2024-01-06")
+        self.assertIn("serie constante", anomalies[0]["motivo"])
+
+    def test_constant_levels_without_break_not_flagged(self):
+        """Niveles previos constantes y último valor igual: sin señal."""
+        values = [100.0, 100.0, 100.0, 100.0, 100.0, 100.0]
+        df = self._make_series(values, code="ipc")
+        anomalies = detect_series_anomalies(df, z_threshold=4.0, min_history=4)
+        self.assertEqual(anomalies, [])
+
 
 # ── validate_distritos_electorales ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Plan 074 — Señal mal atribuida en el guard del IPC

`detect_series_anomalies` saltaba los pares donde `prev_value` o `curr_value` ≤ 0 (común en la variación mensual del IPC, p. ej. 2025-12 = -0.2) y usaba `log_returns[-1]` — el último par **admitido**, que cuando el último punto es ≤ 0 es un par **viejo** — pero reportaba la señal con `dates[-1]`/`values[-1]` del punto nuevo: señal mal atribuida, justo el guard del valor scrapeado del INE.

## Cambios

1. **`validation.py`**: el caso log-válido queda **intacto** (calibración del Plan 054 preservada: z_threshold=4.0, cero falsos positivos en 506 registros reales). El par final no-log-evaluable usa un **detector de nivel** (z-score robusto MAD sobre los niveles previos) con su fecha/valor/motivo correctos.
2. Guards: histórico movido dentro del caso log (no excluye el caso de nivel); guard de serie de 1 elemento.
3. **Tests** (3 nuevos): último punto negativo con fecha correcta, valores negativos sin salto no flaggeados, poco histórico sin señal.

## Verificación

- Calibración real intacta: 0 falsos positivos en el parquet publicado.
- Suite 878 tests + 1 skip; lint, format, doctor verdes.