### PR TITLE
docs: quickstart R, marcas de carril, inventario de extractores (Plan 081)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,10 @@ Actualmente publica veintidós (<!-- START_AGENTS_DATASET_COUNT -->22<!-- END_AG
 | **Finanzas Municipales** | SINIM / SUBDERE | Indicadores financieros municipales anuales por comuna |
 | **Resultados Educacionales** | MINEDUC | Métricas educacionales agregadas por comuna y año, sin registros personales |
 | **Indicadores Urbanos SIEDU** | INE / SIEDU | Indicadores urbanos en formato largo con cobertura parcial esperada |
-| **Perfil Territorial Comunal** | chile-hub derivado | Una fila por comuna con métricas territoriales consolidadas |
+| **Perfil Territorial Comunal** | chile-hub derivado | Una fila por comuna con métricas territoriales consolidadas (carril `candidate`, `review_by` 2026-09-18) |
 | **Empresas (RES)** | Ministerio de Economía / datos.gob.cl | Registro de constituciones de empresas bajo Ley 20.659 con RUT, razón social, tipo societario y comuna |
 | **Pobreza Comunal (SAE)** | MDS / Observatorio Social | Estimaciones de pobreza por ingresos y multidimensional por comuna |
-| **Consumo Eléctrico Comunal** | CNE / Energía Abierta | Consumo eléctrico anual por comuna y tipo de cliente |
+| **Consumo Eléctrico Comunal** | CNE / Energía Abierta | Consumo eléctrico anual por comuna y tipo de cliente (carril `candidate` — fuente CNE descontinuada, `maturity_status: deprecated`) |
 | **Partidos Políticos** | Cámara de Diputados / SERVEL | Roster de partidos políticos vigentes e históricos con estado legal |
 | **Autoridades Electas** | Cámara de Diputados + Senado | Diputados y senadores en ejercicio, con partido y distrito o circunscripción |
 | **Delincuencia Comunal** | CEAD / Subsecretaría de Prevención del Delito | Casos policiales DMCS y otras categorías por comuna y mes (carril `candidate`, ver nota abajo) |
@@ -91,9 +91,10 @@ chile-hub/
 │
 ├── src/
 <!-- START_AGENTS_EXTRACTOR_LIST -->
-│   ├── extractors/                 19 extractores por dataset + 4 módulos compartidos (ver nota abajo)
+│   ├── extractors/                 19 extractores por dataset + 5 módulos compartidos (ver nota abajo)
 │   │   ├── base.py                                       BaseExtractor ABC (contrato para todos los extractores)
 │   │   ├── http_utils.py                                 Reintentos/backoff HTTP compartidos
+│   │   ├── ine_ipc.py                                    Override de IPC desde el INE (fuente autoritativa; Plan 069)
 │   │   ├── region_utils.py                               Normalización de nombres de región compartida
 │   │   ├── source_adapter.py                             Adaptador de fuente compartido
 │   │   ├── autoridades_electas_extractor.py              Diputados y senadores en ejercicio → data/staging/

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **881 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **882 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/docs/datasets/perfil_territorial_comunal.md
+++ b/docs/datasets/perfil_territorial_comunal.md
@@ -1,5 +1,8 @@
 # Perfil Territorial Comunal
 
+> **Carril:** `candidate` — NO incluido en el bundle público. Revisión de
+> carril programada (`review_by` 2026-09-18, ver `data/source_registry.json`).
+
 ## Descripción
 
 Tabla derivada con una fila por comuna que consolida la DPA, Censo 2024, hogares y viviendas, salud, educación, distritos electorales, finanzas municipales, resultados educacionales y resumen SIEDU.

--- a/docs/extraction-lanes.md
+++ b/docs/extraction-lanes.md
@@ -18,16 +18,21 @@ operativa son los workflows, esta página es la vista de referencia.
 1. **Un extractor por carril.** Los extractores diarios corren en `make extract`;
    los mensuales, en `monthly-scrape.yml`; los candidate, en su workflow propio.
    Nunca mezclar un extractor en dos carriles.
-2. **El stub SINIM nunca corre en un job programado.** `sinim_finanzas_extractor.py`
+2. **El override INE es parte del carril diario de `indicadores`.** Cuando
+   mindicador.cl no entrega el IPC del año en curso, `ine_ipc.py` scrapea la
+   variación mensual de la página pública del INE (fuente autoritativa, Plan
+   069) ANTES de recurrir al backfill — el publish diario depende de ese
+   parseo HTML, y su edad está gateada (ADR-016).
+3. **El stub SINIM nunca corre en un job programado.** `sinim_finanzas_extractor.py`
    siempre escribe 3 filas de muestra; el snapshot real mensual vive versionado en
    git y lo restaura `pipeline-check.yml` tras un restore de caché obsoleto.
-3. **Degradación de `autoridades_electas` sin scrapling.** En CI este extractor se
+4. **Degradación de `autoridades_electas` sin scrapling.** En CI este extractor se
    invoca con `uv run --no-project --with "scrapling[fetchers]"` (entorno efímero,
    conflicto de `click` con el extra `dev` — ver `pyproject.toml`). Sin scrapling
    degrada a 155 registros (0 senadores) y rompe el gate "Check build-synced files".
-4. **`perfil_territorial_comunal` no tiene extractor**: es derivado en
+5. **`perfil_territorial_comunal` no tiene extractor**: es derivado en
    `build_dev_db.py` a partir de otros datasets.
-5. **`geometria_comunal` es candidate (ADR-012)**: su artefacto se publica desde
+6. **`geometria_comunal` es candidate (ADR-012)**: su artefacto se publica desde
    `geometria-comunal.yml`, fuera del bundle estable y del guard de 500 KB.
 
 ## Cómo verificar el carril de un dataset

--- a/docs/r-quickstart.md
+++ b/docs/r-quickstart.md
@@ -14,7 +14,7 @@ download.file(url, tmp, mode = "wb")
 unzip(tmp, exdir = "chile-hub-data")
 
 library(arrow)
-comunas <- read_parquet("chile-hub-data/comunas.parquet")
+comunas <- read_parquet("chile-hub-data/data/normalized/comunas.parquet")
 head(comunas)
 ```
 
@@ -23,7 +23,9 @@ Para verificar la integridad del ZIP descargado, compara su hash con el archivo
 (usa el paquete `digest` o `openssl dgst -sha256` en terminal).
 
 > **Nota:** la URL `releases/latest/download/` es estable entre versiones;
-> apunta siempre al release publicado más reciente.
+> apunta siempre al release publicado más reciente. El bundle contiene los
+> artefactos bajo el prefijo `data/normalized/` (ver la Opción B para leer
+> sin descargar).
 
 ## Opción B — Parquet individual por URL directa
 
@@ -40,22 +42,31 @@ Reemplaza `comunas.parquet` por el nombre del dataset que necesitas (ver la
 
 ## Opción C — DuckDB (cruces SQL)
 
-Conecta directamente al archivo DuckDB del bundle para hacer cruces SQL:
+El bundle publicable no incluye `chile_data.duckdb` (no viaja en el ZIP;
+solo se publican Parquet + JSON). Para cruces SQL con DuckDB, lee los
+Parquet directamente desde el bundle descargado:
 
 ```r
 library(duckdb)
-con <- dbConnect(duckdb(), "chile-hub-data/chile_data.duckdb", read_only = TRUE)
+con <- dbConnect(duckdb())
+
+dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
 
 dbGetQuery(con,
   "SELECT c.nombre_comuna, c.nombre_region, cc.poblacion_censada
-   FROM comunas c
-   JOIN censo_comunal cc USING (codigo_comuna)
+   FROM read_parquet('chile-hub-data/data/normalized/comunas.parquet') c
+   JOIN read_parquet('chile-hub-data/data/normalized/censo_comunal.parquet') cc
+     USING (codigo_comuna)
    ORDER BY cc.poblacion_censada DESC
    LIMIT 10"
 )
 
 dbDisconnect(con, shutdown = TRUE)
 ```
+
+> **Nota:** también puedes consultar los Parquet remotos directamente con
+> DuckDB + httpfs (sin descargar el bundle), apuntando a las URLs de la
+> Opción B.
 
 ## Notas importantes
 

--- a/docs/r-quickstart.md
+++ b/docs/r-quickstart.md
@@ -44,13 +44,12 @@ Reemplaza `comunas.parquet` por el nombre del dataset que necesitas (ver la
 
 El bundle publicable no incluye `chile_data.duckdb` (no viaja en el ZIP;
 solo se publican Parquet + JSON). Para cruces SQL con DuckDB, lee los
-Parquet directamente desde el bundle descargado:
+Parquet directamente desde el bundle descargado (rutas locales, sin
+extensiones):
 
 ```r
 library(duckdb)
 con <- dbConnect(duckdb())
-
-dbExecute(con, "INSTALL httpfs; LOAD httpfs;")
 
 dbGetQuery(con,
   "SELECT c.nombre_comuna, c.nombre_region, cc.poblacion_censada
@@ -64,9 +63,10 @@ dbGetQuery(con,
 dbDisconnect(con, shutdown = TRUE)
 ```
 
-> **Nota:** también puedes consultar los Parquet remotos directamente con
-> DuckDB + httpfs (sin descargar el bundle), apuntando a las URLs de la
-> Opción B.
+> **Nota:** las rutas locales no requieren la extensión `httpfs`. Si prefieres
+> consultar los Parquet **remotos** directamente (sin descargar el bundle),
+> ejecuta primero `dbExecute(con, "INSTALL httpfs; LOAD httpfs;")` y usa las
+> URLs de la Opción B.
 
 ## Notas importantes
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -140,7 +140,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 078 | [Paralelizar CEAD y geometría (scrapes secuenciales)](078-parallelize-cead-geometria.md) | P2 | M | MED | — | TODO |
 | 079 | [Cobertura de writers y extractores sin test (geo, CEAD, reports)](079-cover-geo-cead-reports.md) | P2 | M | LOW | 077 (helper) | TODO |
 | 080 | [Higiene de tests (red real, sleeps, staleness, e2e, Makefile)](080-test-hygiene-batch.md) | P3 | M | LOW-MED | — | TODO |
-| 081 | [Docs — quickstart R, marcas de carril, inventario de extractores](081-docs-quickstart-lanes-inventory.md) | P3 | S | LOW | — | TODO |
+| 081 | [Docs — quickstart R, marcas de carril, inventario de extractores](081-docs-quickstart-lanes-inventory.md) | P3 | S | LOW | — | DONE (2026-08-12, commit 6f4c8b2 — quickstart R corregido, carriles marcados, ine_ipc en inventario; branch advisor/081 sin merge) |
 | 082 | [Mostrar el carril candidate en la landing](082-landing-candidate-lane.md) | P3 | M | MED | 070, 071 | TODO |
 | 083 | [Señal proactiva de review_by inminente](083-review-approaching-signal.md) | P3 | S-M | LOW | — | TODO |
 | 084 | [Promover perfil_territorial_comunal al bundle estable](084-promote-perfil-territorial.md) | P3 (decisión) | S-M | MED | 070, 071 | TODO |

--- a/src/builders/doc_sync.py
+++ b/src/builders/doc_sync.py
@@ -250,6 +250,7 @@ _AGENTS_EXTRACTOR_DESCRIPTIONS = {
     "http_utils.py": "Reintentos/backoff HTTP compartidos",
     "region_utils.py": "Normalización de nombres de región compartida",
     "source_adapter.py": "Adaptador de fuente compartido",
+    "ine_ipc.py": "Override de IPC desde el INE (fuente autoritativa; Plan 069)",
     "subdere_extractor.py": (
         "DPA: regiones/provincias/comunas/comunas_enriquecidas (BCN ArcGIS) → data/staging/"
     ),
@@ -293,7 +294,17 @@ _AGENTS_EXTRACTOR_DESCRIPTIONS = {
 
 EXTRACTORS_DIR = os.path.join(ROOT_DIR, "src", "extractors")
 
-_SHARED_MODULES = {"base.py", "http_utils.py", "region_utils.py", "source_adapter.py"}
+_SHARED_MODULES = {
+    "base.py",
+    "http_utils.py",
+    "region_utils.py",
+    "source_adapter.py",
+    # ine_ipc.py no sigue la convención *_extractor (es un override de
+    # último recurso, no un extractor por dataset) pero es parte del carril
+    # diario de indicadores — sin esto, el inventario decía 19 extractores
+    # cuando hay 20 módulos de extracción (Plan 081).
+    "ine_ipc.py",
+}
 
 
 def sync_agents_extractor_list(check_only=False):

--- a/tests/test_pipeline_logic.py
+++ b/tests/test_pipeline_logic.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import os
 import re
 import sys
 import tempfile
@@ -3085,6 +3086,29 @@ class DocSyncTests(unittest.TestCase):
     """Tests para src/builders/doc_sync.py: sincroniza hechos hardcodeados de
     README.md (conteo de tests/ADRs/contratos, badge, pin de versión, salud,
     calidad, redistribución) con su fuente de verdad. Ver AGENTS.md §12."""
+
+    def test_extractor_inventory_includes_ine_ipc(self):
+        """El inventario de extractores de AGENTS.md debe incluir ine_ipc.py.
+
+        Plan 081: ine_ipc.py no sigue la convención *_extractor (es un
+        override de último recurso, no un extractor por dataset), pero es
+        parte del carril diario de indicadores. Sin incluirlo en
+        _SHARED_MODULES, el gate anti-drift decía 19 extractores cuando hay
+        20 módulos de extracción — un punto ciego del §12.
+        """
+        from src.builders import doc_sync
+
+        self.assertIn("ine_ipc.py", doc_sync._SHARED_MODULES)
+        self.assertIn("ine_ipc.py", doc_sync._AGENTS_EXTRACTOR_DESCRIPTIONS)
+        all_extractor_files = {
+            f
+            for f in os.listdir(doc_sync.EXTRACTORS_DIR)
+            if f.endswith(".py") and f != "__init__.py"
+        }
+        listed = set(doc_sync._SHARED_MODULES) | {
+            f for f in all_extractor_files if f.endswith("_extractor.py")
+        }
+        self.assertEqual(all_extractor_files, listed)
 
     def _readme(self, tmpdir, *blocks):
         lines = ["# README de prueba", ""]


### PR DESCRIPTION
## Plan 081 — Tres inconsistencias de documentación

1. **`r-quickstart.md` roto**: la Opción A leía `chile-hub-data/comunas.parquet` (los arcnames del ZIP llevan prefijo `data/normalized/`) y la Opción C abría `chile_data.duckdb` que **no viaja en el bundle**. Corregidas: Opción A con la ruta real, Opción C con DuckDB sobre los Parquet (`INSTALL httpfs`).
2. **AGENTS.md §1**: no marcaba `perfil_territorial_comunal` ni `consumo_electrico_comunal` como candidate (este último deprecated) — la tabla canónica contradecía al registry que cita. Marcadas ambas + header Carril en el doc de perfil.
3. **`ine_ipc.py` invisible**: el gate anti-drift contaba solo `*_extractor.py` (19) cuando hay 20 módulos de extracción, y `extraction-lanes.md` omitía el override INE del carril diario. Ahora `ine_ipc.py` es parte de `_SHARED_MODULES` con descripción; el árbol dice "19 extractores + 5 módulos compartidos".

## Guardrail

`DocSyncTests.test_extractor_inventory_includes_ine_ipc` — verifica que todos los `.py` de `extractors/` estén listados (cierra el punto ciego del §12).

## Verificación

Suite 881 tests + 1 skip; lint, format, doctor verdes.