### PR TITLE
feat(landing): carril candidate visible en la landing (Plan 082)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **882 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **885 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/app.js
+++ b/app.js
@@ -396,6 +396,62 @@ function wireDatasetExampleInteractions() {
     });
 }
 
+function renderCandidateSection(bundle, grid, artifactManifestByPath) {
+    const candidates = bundle.candidate_datasets || [];
+    if (candidates.length === 0) return;
+
+    const cardsHtml = candidates.map(candidate => {
+        const searchable = [candidate.dataset, candidate.maturity_status, candidate.source_detail, candidate.next_action]
+            .filter(Boolean)
+            .join(" ");
+        return `
+            <article class="dataset-card candidate-card" id="candidate-${escapeHtml(candidate.dataset)}" data-search="${escapeHtml(searchable)}">
+                <div class="dataset-card-top">
+                    <div>
+                        <h4 class="dataset-name">${escapeHtml(candidate.dataset)}</h4>
+                        <div class="dataset-desc">Evaluado, no incluido en el bundle público.</div>
+                    </div>
+                    <span class="dataset-badge candidate">candidate</span>
+                </div>
+
+                <div class="dataset-facts-grid">
+                    <div class="dataset-fact-mini">
+                        <span class="dataset-fact-mini-label">Estado</span>
+                        <span class="dataset-fact-mini-value">${escapeHtml(candidate.maturity_status || "unknown")}</span>
+                    </div>
+                    <div class="dataset-fact-mini">
+                        <span class="dataset-fact-mini-label">Fuente</span>
+                        <span class="dataset-fact-mini-value" title="${escapeHtml(candidate.source_detail || "")}">${escapeHtml(candidate.source_detail || "N/D")}</span>
+                    </div>
+                </div>
+
+                <div class="candidate-next-action">${escapeHtml(candidate.next_action || "Sin acción registrada.")}</div>
+
+                <div class="dataset-card-actions">
+                    <a class="btn-card-action muted" href="data/normalized/hub_bundle.json" target="_blank" rel="noopener noreferrer">Ver metadata en Bundle JSON</a>
+                </div>
+            </article>
+        `;
+    }).join("");
+
+    const section = document.createElement("section");
+    section.className = "catalog-category candidate-category";
+    section.id = "cat-candidate";
+    section.innerHTML = `
+        <div class="catalog-category-header">
+            <h3 class="catalog-category-title">
+                En evaluación
+                <span class="candidate-chip">candidate</span>
+                <span class="catalog-category-count">${candidates.length}</span>
+            </h3>
+        </div>
+        <div class="catalog-grid-sub">
+            ${cardsHtml}
+        </div>
+    `;
+    grid.appendChild(section);
+}
+
 function filterCatalog() {
     if (!catalogGrid || !catalogCount) return;
     const query = (catalogSearchInput?.value || "")
@@ -421,7 +477,11 @@ function filterCatalog() {
         cat.hidden = !hasVisibleCards;
     });
 
-    catalogCount.textContent = `${visibleCount} ${visibleCount === 1 ? "capa" : "capas"}`;
+    // El contador refleja solo el catálogo estable: las cards candidate
+    // (carril candidate, fuera del bundle público) filtran pero no cuentan.
+    const stableVisibleCount = [...catalogGrid.querySelectorAll(".dataset-card:not(.candidate-card)")]
+        .filter(card => !card.hidden).length;
+    catalogCount.textContent = `${stableVisibleCount} ${stableVisibleCount === 1 ? "capa" : "capas"}`;
 
     const existingNoResults = catalogGrid.querySelector(".no-results-message");
     if (existingNoResults) existingNoResults.remove();
@@ -981,6 +1041,10 @@ function renderCatalog(bundle) {
         directorios: {
             title: "Directorios Oficiales y Economía",
             datasets: ["establecimientos_salud", "establecimientos_educacionales", "empresas", "indicadores"]
+        },
+        gobierno: {
+            title: "Gobierno y Política",
+            datasets: ["partidos_politicos", "autoridades_electas"]
         }
     };
 
@@ -1059,6 +1123,8 @@ function renderCatalog(bundle) {
     }).join("");
 
     catalogGrid.innerHTML = categoriesHtml;
+
+    renderCandidateSection(bundle, catalogGrid, artifactManifestByPath);
 
     filterCatalog();
 

--- a/index.html
+++ b/index.html
@@ -2597,6 +2597,48 @@
             color: #3730a3;
         }
 
+        .dataset-badge.candidate {
+            background: #f5f3ff;
+            color: #5b21b6;
+            border-color: rgba(91, 33, 182, 0.2);
+        }
+
+        .candidate-card {
+            border-style: dashed;
+            border-color: rgba(91, 33, 182, 0.25);
+            background: linear-gradient(180deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.9));
+        }
+
+        .candidate-card .dataset-card-actions {
+            border-top-color: rgba(91, 33, 182, 0.12);
+        }
+
+        .candidate-next-action {
+            margin-top: 0.75rem;
+            font-size: 0.78rem;
+            line-height: 1.45;
+            color: var(--text-secondary);
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+
+        .candidate-chip {
+            font-family: var(--font-mono);
+            font-size: 0.65rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            background: #f5f3ff;
+            color: #5b21b6;
+            border: 1px solid rgba(91, 33, 182, 0.2);
+            border-radius: 4px;
+            padding: 0.1rem 0.35rem;
+            vertical-align: middle;
+            margin-left: 0.35rem;
+        }
+
         .dataset-facts-grid {
             display: grid;
             grid-template-columns: repeat(2, 1fr);

--- a/plans/README.md
+++ b/plans/README.md
@@ -141,7 +141,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 079 | [Cobertura de writers y extractores sin test (geo, CEAD, reports)](079-cover-geo-cead-reports.md) | P2 | M | LOW | 077 (helper) | TODO |
 | 080 | [Higiene de tests (red real, sleeps, staleness, e2e, Makefile)](080-test-hygiene-batch.md) | P3 | M | LOW-MED | — | TODO |
 | 081 | [Docs — quickstart R, marcas de carril, inventario de extractores](081-docs-quickstart-lanes-inventory.md) | P3 | S | LOW | — | DONE (2026-08-12, commit 6f4c8b2 — quickstart R corregido, carriles marcados, ine_ipc en inventario; branch advisor/081 sin merge) |
-| 082 | [Mostrar el carril candidate en la landing](082-landing-candidate-lane.md) | P3 | M | MED | 070, 071 | TODO |
+| 082 | [Mostrar el carril candidate en la landing](082-landing-candidate-lane.md) | P3 | M | MED | 070, 071 | DONE (2026-08-12) |
 | 083 | [Señal proactiva de review_by inminente](083-review-approaching-signal.md) | P3 | S-M | LOW | — | TODO |
 | 084 | [Promover perfil_territorial_comunal al bundle estable](084-promote-perfil-territorial.md) | P3 (decisión) | S-M | MED | 070, 071 | TODO |
 | 085 | [ADR multi-fuente para el override de IPC](085-adr-multi-source-ipc-override.md) | P3 | M | LOW | 069, 075 | TODO |

--- a/scripts/verify_landing.py
+++ b/scripts/verify_landing.py
@@ -295,7 +295,10 @@ def verify_landing():
 
         # Candidate lane section (Plan 082): the carril candidate must be
         # visible in its own section, filtered by search but excluded from
-        # the stable catalog count.
+        # the stable catalog count. The candidate name searched below is
+        # derived from the bundle (the registry is the source of truth for
+        # lane membership), so promoting a candidate to stable (Plan 084)
+        # does not break this check.
         expected_candidate_count = len(bundle.get("candidate_datasets", []))
         candidate_section = page.locator("#cat-candidate")
         if expected_candidate_count > 0:
@@ -316,10 +319,11 @@ def verify_landing():
                 next_action = card.locator(".candidate-next-action").inner_text()
                 if not next_action.strip():
                     fail(f"Expected non-empty next_action on candidate card {index}")
-            page.fill("#catalog-search-input", "perfil_territorial")
+            first_candidate_name = bundle["candidate_datasets"][0]["dataset"]
+            page.fill("#catalog-search-input", first_candidate_name)
             page.wait_for_timeout(200)
-            if not page.locator("#candidate-perfil_territorial_comunal").is_visible():
-                fail("Expected candidate card to be found by search")
+            if not page.locator(f"#candidate-{first_candidate_name}").is_visible():
+                fail(f"Expected candidate card to be found by search: {first_candidate_name}")
             stable_count_text = page.locator("#catalog-count").inner_text()
             if stable_count_text != "0 capas":
                 fail(

--- a/scripts/verify_landing.py
+++ b/scripts/verify_landing.py
@@ -293,6 +293,45 @@ def verify_landing():
         page.fill("#catalog-search-input", "")
         page.wait_for_timeout(200)
 
+        # Candidate lane section (Plan 082): the carril candidate must be
+        # visible in its own section, filtered by search but excluded from
+        # the stable catalog count.
+        expected_candidate_count = len(bundle.get("candidate_datasets", []))
+        candidate_section = page.locator("#cat-candidate")
+        if expected_candidate_count > 0:
+            if not candidate_section.is_visible():
+                fail(
+                    "Expected #cat-candidate section to be visible with candidate datasets in the bundle"
+                )
+            candidate_cards = page.locator(".candidate-card")
+            if candidate_cards.count() != expected_candidate_count:
+                fail(
+                    f"Expected {expected_candidate_count} candidate cards, got {candidate_cards.count()}"
+                )
+            for index in range(candidate_cards.count()):
+                card = candidate_cards.nth(index)
+                badge = card.locator(".dataset-badge.candidate")
+                if badge.count() != 1 or badge.inner_text().strip().lower() != "candidate":
+                    fail(f"Expected candidate badge on candidate card {index}")
+                next_action = card.locator(".candidate-next-action").inner_text()
+                if not next_action.strip():
+                    fail(f"Expected non-empty next_action on candidate card {index}")
+            page.fill("#catalog-search-input", "perfil_territorial")
+            page.wait_for_timeout(200)
+            if not page.locator("#candidate-perfil_territorial_comunal").is_visible():
+                fail("Expected candidate card to be found by search")
+            stable_count_text = page.locator("#catalog-count").inner_text()
+            if stable_count_text != "0 capas":
+                fail(
+                    f"Expected candidate search to keep stable count at 0, got '{stable_count_text}'"
+                )
+            page.fill("#catalog-search-input", "")
+            page.wait_for_timeout(200)
+            stable_count_text = page.locator("#catalog-count").inner_text()
+            expected_stable = str(len(bundle.get("datasets", [])))
+            if stable_count_text.split(" ")[0] != expected_stable:
+                fail(f"Expected stable catalog count {expected_stable}, got '{stable_count_text}'")
+
         repo_href = page.get_by_role("link", name="GitHub Repo").get_attribute("href")
         if repo_href != "https://github.com/cortega26/chile-hub":
             fail(f"Unexpected repo href: {repo_href}")

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -780,6 +780,46 @@ class HfPublishJobGuardrailTests(unittest.TestCase):
                 in_needs_block = False
 
 
+class LandingCandidateLaneGuardrailTests(unittest.TestCase):
+    """Plan 082: la landing debe exponer el carril candidate sin contaminar
+    el catálogo estable.
+
+    Antes de este plan, hub_bundle.json producía candidate_datasets que
+    ninguna UI consumía — perfil_territorial_comunal (346/346, validation
+    ok) era invisible en la superficie principal. Si una futura refactor de
+    app.js eliminara el render candidate o el contador del buscador volviera
+    a contar candidate cards, los consumidores del sitio perderían la única
+    señal visual de qué datasets NO están en el bundle público.
+    """
+
+    def _app_js(self):
+        return (ROOT_DIR / "app.js").read_text(encoding="utf-8")
+
+    def test_app_js_renders_candidate_section_from_bundle(self):
+        content = self._app_js()
+        self.assertIn("renderCandidateSection", content)
+        self.assertIn("bundle.candidate_datasets", content)
+        self.assertIn('section.id = "cat-candidate"', content)
+        self.assertIn('class="dataset-badge candidate"', content)
+        self.assertIn("candidate-next-action", content)
+        self.assertIn('href="data/normalized/hub_bundle.json"', content)
+
+    def test_search_count_excludes_candidate_cards(self):
+        content = self._app_js()
+        self.assertIn('.dataset-card:not(.candidate-card)")', content)
+        self.assertIn("stableVisibleCount", content)
+        self.assertIn("catalogCount.textContent = `", content)
+        no_result = "if (visibleCount === 0 && cards.length > 0)"
+        self.assertIn(no_result, content)
+
+    def test_verify_landing_checks_candidate_section(self):
+        content = (ROOT_DIR / "scripts" / "verify_landing.py").read_text(encoding="utf-8")
+        self.assertIn("#cat-candidate", content)
+        self.assertIn("candidate_datasets", content)
+        self.assertIn(".candidate-card", content)
+        self.assertIn('"0 capas"', content)
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Plan 082 — El carril candidate sale a la superficie

**Por qué:** `hub_bundle.json` producía `candidate_datasets` que ninguna UI consumía. `perfil_territorial_comunal` (346/346, validation ok, 9 datasets consolidados) era invisible — un analista no podía saber que existe ni que no está en el bundle público.

### Cambios

1. **`app.js` — `renderCandidateSection()`**: sección "En evaluación" al final del catálogo con badge `candidate`, `maturity_status`, `source_detail` y `next_action`. Participa del buscador pero **no cuenta** en el total estable (`filterCatalog` excluye `.candidate-card`).
2. **Bug preexistente descubierto y corregido**: `CATEGORIES` cubría solo 15 de 17 datasets estables — `partidos_politicos` y `autoridades_electas` nunca se renderizaban en el grid (el hero decía 17, el grid 15). Nueva categoría "Gobierno y Política".
3. **`index.html`**: estilos `.candidate-*` (borde punteado, badge violeta, chip).
4. **`verify_landing.py`**: checks Playwright — sección visible, N cards con badge + next_action, búsqueda encuentra candidate sin mover el contador estable, contador final == `len(bundle.datasets)` (17).
5. **`test_ci_config.py`**: `LandingCandidateLaneGuardrailTests` (3 tests de texto, patrón del archivo).

### Verificación

884 tests + 1 skip · lint/format/doctor verdes · `make verify-landing` exit 0