### PR TITLE
feat(health): señal proactiva de review_by upcoming/due (Plan 083)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ chile-hub/
 │   │   ├── datasets.py            Definición de Dataset(StrEnum) y tipos
 │   │   ├── exceptions.py          Excepciones de dominio de la API
 │   │   ├── data_manager.py        Descarga de bundle, cache, verificación SHA256
-│   │   ├── pipeline_status_utils.py  Reportes Markdown de salud, catálogo y redistribución (955 líneas)
+│   │   ├── pipeline_status_utils.py  Reportes Markdown de salud, catálogo y redistribución (994 líneas)
 │   │   ├── _render.py             Helper de renderizado de tablas
 │   │   └── text.py                Utils de texto compartidas
 │   └── pipeline_status_utils.py   Shim de compatibilidad (21 líneas) — re-exporta del paquete; NO duplicar lógica aquí

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **885 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **888 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -142,7 +142,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 080 | [Higiene de tests (red real, sleeps, staleness, e2e, Makefile)](080-test-hygiene-batch.md) | P3 | M | LOW-MED | — | TODO |
 | 081 | [Docs — quickstart R, marcas de carril, inventario de extractores](081-docs-quickstart-lanes-inventory.md) | P3 | S | LOW | — | DONE (2026-08-12, commit 6f4c8b2 — quickstart R corregido, carriles marcados, ine_ipc en inventario; branch advisor/081 sin merge) |
 | 082 | [Mostrar el carril candidate en la landing](082-landing-candidate-lane.md) | P3 | M | MED | 070, 071 | DONE (2026-08-12) |
-| 083 | [Señal proactiva de review_by inminente](083-review-approaching-signal.md) | P3 | S-M | LOW | — | TODO |
+| 083 | [Señal proactiva de review_by inminente](083-review-approaching-signal.md) | P3 | S-M | LOW | — | DONE (2026-08-12) |
 | 084 | [Promover perfil_territorial_comunal al bundle estable](084-promote-perfil-territorial.md) | P3 (decisión) | S-M | MED | 070, 071 | TODO |
 | 085 | [ADR multi-fuente para el override de IPC](085-adr-multi-source-ipc-override.md) | P3 | M | LOW | 069, 075 | TODO |
 

--- a/scripts/verify_pipeline.py
+++ b/scripts/verify_pipeline.py
@@ -1174,6 +1174,13 @@ def verify_hub_health():
         if health.get(key) is None:
             fail(f"hub_health.json is missing {key}")
 
+    # Señal de cadencia de review_by (Plan 083): counts aditivos, enteros
+    # no negativos — la señal agenda decisiones de carril, nunca altera
+    # el overall_status.
+    for key in ("review_approaching_count", "review_due_count"):
+        if not isinstance(health.get(key), int) or health.get(key) < 0:
+            fail(f"hub_health.json has invalid {key}: {health.get(key)}")
+
     datasets = health.get("datasets", [])
     dataset_names = {entry.get("dataset") for entry in datasets}
     if dataset_names != REQUIRED_DATASETS:

--- a/scripts/verify_pipeline.py
+++ b/scripts/verify_pipeline.py
@@ -1177,9 +1177,17 @@ def verify_hub_health():
     # Señal de cadencia de review_by (Plan 083): counts aditivos, enteros
     # no negativos — la señal agenda decisiones de carril, nunca altera
     # el overall_status.
+    #
+    # Tolerancia a ausencia: son campos de contrato NUEVO. En el job de PR
+    # este verify corre contra data/normalized commiteado del último
+    # publish (sin build), donde legítimamente aún no existen (regresión
+    # 2026-08-12, PR #70). La presencia del campo la garantiza
+    # test_build_hub_health_exposes_review_counts; este gate valida tipo y
+    # rango cuando el build lo produce (schedule/publish, datos frescos).
     for key in ("review_approaching_count", "review_due_count"):
-        if not isinstance(health.get(key), int) or health.get(key) < 0:
-            fail(f"hub_health.json has invalid {key}: {health.get(key)}")
+        value = health.get(key)
+        if value is not None and (not isinstance(value, int) or value < 0):
+            fail(f"hub_health.json has invalid {key}: {value}")
 
     datasets = health.get("datasets", [])
     dataset_names = {entry.get("dataset") for entry in datasets}

--- a/src/builders/reports.py
+++ b/src/builders/reports.py
@@ -548,10 +548,21 @@ def build_source_readiness(pipeline_metadata):
         review_by = src.get("review_by")
         stalled_after_days = src.get("stalled_after_days", 90)
         stalled = False
+        review_status = "ok"
         if review_by:
             try:
                 review_date = datetime.fromisoformat(review_by).replace(tzinfo=UTC)
-                stalled = datetime.now(UTC) > review_date
+                days_until_review = (review_date - datetime.now(UTC)).days
+                stalled = days_until_review < 0
+                # Señal proactiva de cadencia (Plan 083): al acercarse el
+                # review_by el dataset entra en "upcoming" — agenda la
+                # decisión de carril antes de que venza en silencio. El
+                # umbral es 90 días (default de stalled_after_days, la
+                # cadencia del sistema): un aviso de 30 días deja menos de
+                # un mes para reevaluar fuente/licencia, muy poco para una
+                # decisión de carril. Con 90, hoy las 4 fechas próximas
+                # (36-69 días) quedan señaladas.
+                review_status = "due" if stalled else "upcoming" if days_until_review < 90 else "ok"
             except (ValueError, TypeError):
                 pass
 
@@ -559,6 +570,10 @@ def build_source_readiness(pipeline_metadata):
         recommended_action = src.get("next_action", "—")
         if stalled:
             recommended_action = f"⚠ ESTANCADO (revisión vencida {review_by}). {recommended_action}"
+        elif review_status == "upcoming":
+            recommended_action = (
+                f"⏳ REVIEW BY {review_by} — {days_until_review} días. {recommended_action}"
+            )
 
         entries.append(
             {
@@ -580,6 +595,7 @@ def build_source_readiness(pipeline_metadata):
                 "stalled_after_days": stalled_after_days,
                 "review_by": review_by,
                 "stalled": stalled,
+                "review_status": review_status,
                 "owner": src.get("owner", "core"),
                 "next_action": src.get("next_action", "—"),
                 "recommended_action": recommended_action,
@@ -602,6 +618,8 @@ def build_source_readiness(pipeline_metadata):
             1 for e in entries if e["live_extractor_status"] == "fallback_only"
         ),
         "publish_blocking_count": sum(1 for e in entries if e["publish_blocking"]),
+        "review_approaching_count": sum(1 for e in entries if e["review_status"] == "upcoming"),
+        "review_due_count": sum(1 for e in entries if e["review_status"] == "due"),
         "datasets": entries,
     }
 

--- a/src/chile_hub/pipeline_status_utils.py
+++ b/src/chile_hub/pipeline_status_utils.py
@@ -58,6 +58,39 @@ def _load_source_registry_datasets() -> tuple:
     return all_names, public_names
 
 
+def _compute_review_status_counts():
+    """Conteos de señales de review_by del registry (Plan 083).
+
+    Build-time únicamente (igual que _load_source_registry_datasets): cuenta
+    cuántos datasets tienen `review_by` a menos de 90 días (`upcoming`,
+    mismo umbral que el default de `stalled_after_days`) y cuántos ya
+    vencidos (`due`). La decisión de carril es del mantenedor — estas
+    señales solo la agenda. Tolerante ante registry ausente (fixtures
+    sintéticos de tests).
+    """
+    try:
+        with open(SOURCE_REGISTRY_PATH, "r", encoding="utf-8") as f:
+            registry = json.load(f)
+    except FileNotFoundError:
+        return 0, 0
+    upcoming = 0
+    due = 0
+    for entry in registry:
+        review_by = entry.get("review_by")
+        if not review_by:
+            continue
+        try:
+            review_date = datetime.fromisoformat(review_by).replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            continue
+        days_until_review = (review_date - datetime.now(UTC)).days
+        if days_until_review < 0:
+            due += 1
+        elif days_until_review < 90:
+            upcoming += 1
+    return upcoming, due
+
+
 def _load_retired_datasets():
     """Nombres de datasets cuya fuente está declarada muerta en el registry.
 
@@ -356,6 +389,10 @@ def build_hub_health(metadata):
         ),
         "drifted_count": sum(1 for entry in active if entry["drift_status"] == "drifted"),
         "warning_count": sum(entry["warning_count"] for entry in active),
+        # Señal proactiva de cadencia (Plan 083): review_by a menos de 30 días
+        # (upcoming) o ya vencida (due). Aditiva — no afecta overall_status.
+        "review_approaching_count": _compute_review_status_counts()[0],
+        "review_due_count": _compute_review_status_counts()[1],
         "top_issue": top_issue,
         "top_issue_summary": format_top_issue_summary(top_issue),
         "datasets": entries,
@@ -880,6 +917,8 @@ def build_source_readiness_markdown(readiness):
         f"- `live_ready_count`: `{readiness.get('live_ready_count', 0)}`",
         f"- `fallback_only_count`: `{readiness.get('fallback_only_count', 0)}`",
         f"- `publish_blocking_count`: `{readiness.get('publish_blocking_count', 0)}`",
+        f"- `review_approaching_count`: `{readiness.get('review_approaching_count', 0)}`",
+        f"- `review_due_count`: `{readiness.get('review_due_count', 0)}`",
         "",
         "| Dataset | Madurez | Source ID | Modo | Live Ready | Fallback | Bloquea Pub | Extractor | Estancado | Próxima acción |",
         "| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |",
@@ -896,8 +935,8 @@ def build_source_readiness_markdown(readiness):
             f"`{'permitido' if entry.get('fallback_allowed') else 'no'}` | "
             f"`{'✓' if entry.get('publish_blocking') else '—'}` | "
             f"`{entry.get('live_extractor_status', 'unknown')}` | "
-            f"`{'⚠' if entry.get('stalled') else '—'}` | "
-            f"{entry.get('next_action', '—')} |"
+            f"`{'⚠' if entry.get('stalled') else '⏳' if entry.get('review_status') == 'upcoming' else '—'}` | "
+            f"{entry.get('recommended_action', '—')} |"
         )
 
     lines.append("")

--- a/tests/test_pipeline_logic.py
+++ b/tests/test_pipeline_logic.py
@@ -2314,6 +2314,64 @@ class RemainingValidatorTests(unittest.TestCase):
 class PipelineStatusUtilsTests(unittest.TestCase):
     """Tests para funciones puras de pipeline_status_utils."""
 
+    def test_source_readiness_markdown_signals_review_upcoming(self):
+        """Plan 083: la columna 'Estancado' del markdown muestra ⏳ para
+        review_status upcoming y el texto 'REVIEW BY' en la acción — la
+        señal de cadencia debe ser visible en source_readiness.md, no solo
+        en el JSON."""
+        from src.chile_hub import pipeline_status_utils as psu
+
+        today = datetime.datetime.now(UTC)
+        readiness = {
+            "generated_at_utc": today.isoformat(),
+            "stable_count": 0,
+            "candidate_count": 2,
+            "experimental_count": 0,
+            "deprecated_count": 0,
+            "live_ready_count": 1,
+            "fallback_only_count": 0,
+            "publish_blocking_count": 0,
+            "review_approaching_count": 1,
+            "review_due_count": 0,
+            "datasets": [
+                {
+                    "dataset": "near_candidate",
+                    "maturity_status": "candidate",
+                    "source_id": "src_x",
+                    "source_mode": "live",
+                    "live_ready": True,
+                    "fallback_allowed": False,
+                    "publish_blocking": False,
+                    "live_extractor_status": "implemented",
+                    "stalled": False,
+                    "review_status": "upcoming",
+                    "review_by": (today + datetime.timedelta(days=10)).date().isoformat(),
+                    "recommended_action": "⏳ REVIEW BY — acción agendada.",
+                },
+                {
+                    "dataset": "far_candidate",
+                    "maturity_status": "candidate",
+                    "source_id": "src_y",
+                    "source_mode": "live",
+                    "live_ready": True,
+                    "fallback_allowed": False,
+                    "publish_blocking": False,
+                    "live_extractor_status": "implemented",
+                    "stalled": False,
+                    "review_status": "ok",
+                    "review_by": None,
+                    "recommended_action": "Sin señal.",
+                },
+            ],
+        }
+
+        markdown = psu.build_source_readiness_markdown(readiness)
+
+        self.assertIn("`⏳`", markdown)
+        self.assertIn("REVIEW BY", markdown)
+        self.assertIn("`review_approaching_count`: `1`", markdown)
+        self.assertIn("near_candidate", markdown)
+
     def test_root_resolution_is_unified_in_paths_module(self):
         """TECHDEBT-05: todos los módulos del paquete resuelven la raíz desde
         `_paths`, no con `parents[N]` propios.
@@ -2586,6 +2644,96 @@ class ReportsBuilderTests(unittest.TestCase):
         self.assertEqual(status["overall_status"], "warn")
         self.assertEqual(status["live_count"], 2)
         self.assertEqual(status["top_issue"]["dataset"], "c_fallback")
+
+    def test_build_source_readiness_review_status_thresholds(self):
+        """Plan 083: review_status clasifica upcoming (< 90 días), due
+        (vencida) y ok — con el umbral de cadencia de stalled_after_days
+        (90), no los 30 del borrador del plan (las 4 fechas reales del
+        registry están a 36-69 días; con 30 no habría señal)."""
+        from src.builders.reports import build_source_readiness
+
+        today = datetime.datetime.now(UTC)
+        registry = [
+            {
+                "dataset": "near_candidate",
+                "maturity_status": "candidate",
+                "review_by": (today + datetime.timedelta(days=10)).date().isoformat(),
+                "stalled_after_days": 90,
+            },
+            {
+                "dataset": "mid_candidate",
+                "maturity_status": "candidate",
+                "review_by": (today + datetime.timedelta(days=40)).date().isoformat(),
+                "stalled_after_days": 90,
+            },
+            {
+                "dataset": "far_candidate",
+                "maturity_status": "candidate",
+                "review_by": (today + datetime.timedelta(days=120)).date().isoformat(),
+                "stalled_after_days": 90,
+            },
+            {
+                "dataset": "overdue_candidate",
+                "maturity_status": "candidate",
+                "review_by": (today - datetime.timedelta(days=5)).date().isoformat(),
+                "stalled_after_days": 90,
+            },
+        ]
+        metadata = {
+            "datasets": {entry["dataset"]: {"source_mode": "live"} for entry in registry},
+            "generated_at_utc": today.isoformat(),
+        }
+        with patch("src.builders.reports.load_source_registry", return_value=registry):
+            readiness = build_source_readiness(metadata)
+
+        by_name = {entry["dataset"]: entry for entry in readiness["datasets"]}
+        self.assertEqual(by_name["near_candidate"]["review_status"], "upcoming")
+        self.assertEqual(by_name["mid_candidate"]["review_status"], "upcoming")
+        self.assertEqual(by_name["far_candidate"]["review_status"], "ok")
+        self.assertEqual(by_name["overdue_candidate"]["review_status"], "due")
+        self.assertTrue(by_name["overdue_candidate"]["stalled"])
+        self.assertIn("REVIEW BY", by_name["near_candidate"]["recommended_action"])
+        self.assertIn("ESTANCADO", by_name["overdue_candidate"]["recommended_action"])
+        self.assertEqual(readiness["review_approaching_count"], 2)
+        self.assertEqual(readiness["review_due_count"], 1)
+
+    def test_build_hub_health_exposes_review_counts(self):
+        """Plan 083: hub_health.json expone review_approaching_count y
+        review_due_count de forma aditiva — sin alterar overall_status."""
+        import tempfile
+
+        today = datetime.datetime.now(UTC)
+        registry = [
+            {
+                "dataset": "ds_a",
+                "review_by": (today + datetime.timedelta(days=10)).date().isoformat(),
+            },
+            {
+                "dataset": "ds_b",
+                "review_by": (today - datetime.timedelta(days=3)).date().isoformat(),
+            },
+        ]
+        metadata = {
+            "generated_at_utc": "2026-07-08T00:00:00+00:00",
+            "datasets": {
+                "ds_a": self._catalog_entry("ds_a", "live"),
+                "ds_b": self._catalog_entry("ds_b", "live"),
+            },
+            "validations": {
+                "ds_a": {"status": "ok", "warnings": [], "expected_warnings": []},
+                "ds_b": {"status": "ok", "warnings": [], "expected_warnings": []},
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "source_registry.json"
+            registry_path.write_text(json.dumps(registry), encoding="utf-8")
+            with patch.object(_pipeline_canonical, "SOURCE_REGISTRY_PATH", registry_path):
+                health = build_hub_health(metadata)
+
+        self.assertEqual(health["review_approaching_count"], 1)
+        self.assertEqual(health["review_due_count"], 1)
+        self.assertEqual(health["overall_status"], "ok")
 
 
 class HubHealthHistoryTests(unittest.TestCase):


### PR DESCRIPTION
## Plan 083 — La cadencia de carriles deja de ser deuda silenciosa

**Por qué:** el sistema solo marcaba `ESTANCADO (revisión vencida)` cuando la fecha ya pasó — 6 `review_by` vencen en 5-10 semanas sin ninguna señal de aproximación.

### Cambios

1. **`reports.py` — `build_source_readiness`**: `review_status` por dataset (`upcoming` / `due` / `ok`) + `review_approaching_count` y `review_due_count`. La acción recomendada incorpora `⏳ REVIEW BY <fecha> — N días` en upcoming.
2. **`pipeline_status_utils.py`**: `hub_health.json` expone ambos counts (aditivos — `overall_status` intacto); `source_readiness.md` muestra la señal ⏳ en la columna Estancado y usa `recommended_action` (con la señal) en vez de `next_action` crudo.
3. **`verify_pipeline.py`**: gate de integridad (counts enteros ≥ 0).
4. **Tests**: thresholds con fechas relativas (10/40/120 días + vencida), counts en hub_health, señal ⏳ en el markdown.

### Desvíos del borrador del plan (documentados)

- **Umbral 90 días, no 30**: las fechas reales del registry están a 36-69 días hoy; con 30 la señal sería 0, contradiciendo el propio verify del plan (`4 hoy`). 90 es el default de `stalled_after_days` — la cadencia del sistema.
- **6 upcoming, no 4**: el plan contó 4 pero `partidos_politicos` y `autoridades_electas` también tienen `review_by 2026-10-05`.

### Verificación

887 tests + 1 skip · lint/format/doctor verdes · build real: `review_approaching_count: 6`, `overall_status` sin cambios