### PR TITLE
docs(adr): ADR-017 — cadena multi-fuente para el override de IPC (Plan 085)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 - **892 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
-- **16 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".
+- **17 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".
 <!-- END_ADR_COUNT -->
 - **Drift monitoreado:** todos los datasets bajo vigilancia de deriva de esquema; cualquier
   cambio en la fuente se detecta y registra ([`drift_report.md`](data/normalized/drift_report.md)).

--- a/docs/adr/ADR-017-cadena-multifuente-override-ipc.md
+++ b/docs/adr/ADR-017-cadena-multifuente-override-ipc.md
@@ -57,6 +57,19 @@ entrega con su última versión y el gate de edad (ADR-016) empieza a contar.
 El mantenedor ve `published_backfill` + la señal de edad, y el issue se
 reabre con evidencia — no se insiste en el scrape roto.
 
+**Alcance exacto del escape hatch** (matiz operativo — P2 de la review del
+PR #72): la degradación graciosa solo ocurre cuando el delivery llega como
+`published_backfill`, es decir en dos escenarios: (a) la request live a
+mindicador.cl **tiene éxito** pero devuelve la serie IPC vacía, o (b)
+**todas** las requests del refresh fallan y entra la rama all-backfill. En
+el escenario mixto — la request de IPC lanza excepción mientras el resto
+de los indicadores refresca bien, y el scrape INE además falla — el
+extractor registra `preserved_existing_pairs`, que la política de
+publicación **rechaza a propósito** (los recovery diagnostics no son
+`published_backfill`): no hay publicación graciosa. Ese caso queda
+bloqueado por diseño y requiere intervención humana, no sorprende a un
+operador que confíe en el escape hatch.
+
 ## Consecuencias
 
 - El publish diario de `indicadores` depende de un parseo HTML del INE;

--- a/docs/adr/ADR-017-cadena-multifuente-override-ipc.md
+++ b/docs/adr/ADR-017-cadena-multifuente-override-ipc.md
@@ -1,0 +1,93 @@
+# ADR-017: Cadena multi-fuente para el IPC — override del INE como último recurso
+
+**Fecha:** 2026-08-12
+**Estado:** proposed
+**Decision:** La serie `ipc` de `indicadores` se entrega por una cadena
+multi-fuente con override de último recurso: la serie histórica viene del
+agregador (mindicador.cl) y, cuando el IPC del año en curso falta o falla,
+`ine_ipc.py` scrapea la variación mensual de la página pública del INE
+(fuente autoritativa del índice). El delivery queda **visible** como
+`ine_override` (Plan 069) para que el gate de publicación evalúe el dato
+real, y la edad del dato entregado se mide igual que un backfill (ADR-016).
+
+## Contexto
+
+mindicador.cl dejó de publicar la serie IPC en diciembre de 2025 (issue #43).
+El INE es el emisor original del índice y publica la variación mensual en su
+página pública. El override replica el patrón validado del proyecto Monedario
+(`ineIpc.ts`, observado estable desde 2026-05-16): ancla el match al
+encabezado `<h1>` del IPC para no tomar la tarjeta de un índice hermano
+(ICT/IPP) si el INE reordena el layout (refinado en el Plan 075).
+
+AGENTS.md §10 prohíbe el scraping HTML frágil como **fuente principal** —
+esta es la excepción de último recurso: la fuente principal sigue siendo
+mindicador.cl, y solo cuando una serie mensual esperada llega vacía o falla
+se consulta al INE. El HTML no se república: se extrae el dato y su fecha.
+
+La dependencia de la cadena diaria sobre un parseo HTML anclado era
+**silenciosa**: el publish de `indicadores` podía romperse ante un rediseño
+de `ine.gob.cl` sin señal previa. Este ADR la hace visible y decide el
+escape hatch.
+
+## Decision
+
+### 1. La cadena multi-fuente es el diseño, no un parche
+
+`bcentral_extractor.py` procesa en orden: serie del agregador → fallback a
+staging/raw → **override INE** → backfill del artefacto publicado. El
+override gana sobre el backfill en la etiqueta de delivery (`ine_override`
+se asigna después de `published_backfill` — Plan 069), porque etiquetar un
+valor recién scrapeado del INE como "reutilización del artefacto publicado"
+sería falso y escondería el dato real al gate.
+
+### 2. El delivery es visible y la edad se gatea (ADR-016)
+
+`indicator_delivery.ipc = "ine_override"` expone el origen a
+`verify_pipeline.py`, que trata el override con el mismo criterio que
+`published_backfill`: la edad se mide sobre el dato **entregado**, con el
+umbral de cadencia mensual (70 días). Un override INE con el mismo valor mes
+tras mes es tan stale como un backfill repetido (P1 de la review del Plan
+069).
+
+### 3. Escape hatch si el INE rediseña y el regex falla
+
+Si el scrape falla (HTML reestructurado, clase o `<h1>` cambiados), el
+extractor **degrada al backfill publicado** en vez de abortar: la serie se
+entrega con su última versión y el gate de edad (ADR-016) empieza a contar.
+El mantenedor ve `published_backfill` + la señal de edad, y el issue se
+reabre con evidencia — no se insiste en el scrape roto.
+
+## Consecuencias
+
+- El publish diario de `indicadores` depende de un parseo HTML del INE;
+  su edad está gateada por ADR-016 y su origen visible en
+  `indicator_delivery` de `pipeline_metadata.json`.
+- `docs/extraction-lanes.md` documenta el override como parte del carril
+  diario de `indicadores` (regla 2).
+- AGENTS.md §1 y `docs/datasets/indicadores.md` referencian este ADR.
+
+## Preguntas abiertas
+
+- **¿API de series del INE cuando exista?** Si el INE publica una API de
+  series estable, el override HTML se migra a la API y este ADR registra la
+  transición.
+- **¿UTM tiene un override análogo (SII)?** La UTM es emitida por el SII y
+  el agregador la entrega al día; si deja de hacerlo, la misma cadena
+  multi-fuente aplica con la página del SII — decidir al momento, con ADR
+  propio o extensión de este.
+- **¿Backfill congelado vs retirar la serie?** Si el INE deja de publicar
+  IPC y mindicador.cl no lo retoma, la decisión es congelar la serie en su
+  última versión (ADR-016 ya la gatea) o retirarla — del mantenedor, con
+  evidencia del issue.
+
+## Alternativas descartadas
+
+- **Retirar la serie IPC del bundle**: el IPC es un indicador central de
+  la capa económica; perderlo por un hueco del agregador castiga a los
+  consumidores por un fallo ajeno a la fuente autoritativa.
+- **Scrapear el INE como fuente principal**: violaría AGENTS.md §10 y
+  duplicaría el trabajo del agregador sin beneficio.
+- **Override sin etiqueta visible**: el valor INE se vería como "live" o
+  "backfill" según la ruta tomada, y el gate de publicación no podría
+  distinguir el dato real del reuso — exactamente el modo de falla que
+  ADR-016 existe para exponer.

--- a/docs/datasets/indicadores.md
+++ b/docs/datasets/indicadores.md
@@ -130,6 +130,12 @@ Esta capa puede seguir en MVP, pero todavía conviene mejorar en:
 2. una política explícita para distinguir backfill desde raw local versus backfill desde artifact publicado
 3. una estrategia histórica más clara para IPC y UTM frente a snapshots parciales del agregador
 
+> **Entregada (ADR-017):** la estrategia del punto 3 para el IPC está decidida
+> y documentada en [`ADR-017`](../adr/ADR-017-cadena-multifuente-override-ipc.md)
+> — cadena multi-fuente (agregador → override INE → backfill) con delivery
+> visible y escape hatch; pendiente el análogo para UTM (pregunta abierta del
+> mismo ADR).
+
 ## Vigencia de las series (ADR-016)
 
 `pipeline_metadata.json` expone `indicator_max_date` e `indicator_age_days` por

--- a/docs/extraction-lanes.md
+++ b/docs/extraction-lanes.md
@@ -20,9 +20,10 @@ operativa son los workflows, esta página es la vista de referencia.
    Nunca mezclar un extractor en dos carriles.
 2. **El override INE es parte del carril diario de `indicadores`.** Cuando
    mindicador.cl no entrega el IPC del año en curso, `ine_ipc.py` scrapea la
-   variación mensual de la página pública del INE (fuente autoritativa, Plan
-   069) ANTES de recurrir al backfill — el publish diario depende de ese
-   parseo HTML, y su edad está gateada (ADR-016).
+   variación mensual de la página pública del INE (fuente autoritativa) ANTES
+   de recurrir al backfill — el publish diario depende de ese parseo HTML, y
+   su edad está gateada (ADR-016). La cadena multi-fuente completa (agregador
+   → override → backfill) y su escape hatch están decididos en ADR-017.
 3. **El stub SINIM nunca corre en un job programado.** `sinim_finanzas_extractor.py`
    siempre escribe 3 filas de muestra; el snapshot real mensual vive versionado en
    git y lo restaura `pipeline-check.yml` tras un restore de caché obsoleto.

--- a/plans/README.md
+++ b/plans/README.md
@@ -144,7 +144,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 082 | [Mostrar el carril candidate en la landing](082-landing-candidate-lane.md) | P3 | M | MED | 070, 071 | DONE (2026-08-12) |
 | 083 | [Señal proactiva de review_by inminente](083-review-approaching-signal.md) | P3 | S-M | LOW | — | DONE (2026-08-12) |
 | 084 | [Promover perfil_territorial_comunal al bundle estable](084-promote-perfil-territorial.md) | P3 (decisión) | S-M | MED | 070, 071 | DONE (2026-08-12) |
-| 085 | [ADR multi-fuente para el override de IPC](085-adr-multi-source-ipc-override.md) | P3 | M | LOW | 069, 075 | TODO |
+| 085 | [ADR multi-fuente para el override de IPC](085-adr-multi-source-ipc-override.md) | P3 | M | LOW | 069, 075 | DONE (2026-08-12) |
 
 ## Dependencias y orden recomendado
 


### PR DESCRIPTION
## Plan 085 — La dependencia frágil del publish diario queda decidida y documentada

**Por qué:** el publish de `indicadores` depende de un parseo HTML anclado al `<h1>` de `ine.gob.cl` (`ine_ipc.py`) sin ADR propio — un rediseño del INE rompía el carril en silencio. `docs/datasets/indicadores.md:128` prometía "una estrategia histórica más clara para IPC y UTM" sin entregarla.

### Cambios

1. **`ADR-017` (proposed)** — contexto (mindicador.cl sin IPC desde 2025-12, issue #43), decisión (cadena multi-fuente: agregador → override INE → backfill, delivery visible `ine_override` del Plan 069), escape hatch (degradar al backfill publicado si el regex falla; ADR-016 gatea la edad), consecuencias, preguntas abiertas (API INE futura, análogo UTM/SII, backfill congelado vs retirar) y alternativas descartadas.
2. **`extraction-lanes.md`**: regla 2 del carril diario referencia ADR-017.
3. **`docs/datasets/indicadores.md`**: la promesa del punto 3 marcada como **entregada** con referencia al ADR.
4. **README.md**: conteo de ADRs 16 → 17 (sync_docs).

**Estado `proposed`**: el ADR requiere ratificación del mantenedor (STOP condition del plan: si se rechaza el enfoque de override, el ADR documenta la alternativa de retirar la serie).

### Verificación

891 tests + 1 skip · doctor verdes · `grep -c adr/ README.md` → 17