### PR TITLE
fix(ine): acoplar valor y período en el regex del override (Plan 075)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **892 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **895 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **17 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **895 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **896 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **17 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -134,7 +134,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 072 | [Validar miembros del ZIP antes de extractall (zip-slip/symlink)](072-zip-slip-guard.md) | P2 | S | LOW | — | DONE (2026-08-12, commit a1e50d3 — guard en _extract_bundle; branch advisor/072 sin merge) |
 | 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | DONE (2026-08-12, commit 97f184d — contratos en el wheel + fallback; branch advisor/073 sin merge) |
 | 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | DONE (2026-08-12, commit 1b95c1c — detector de nivel para punto ≤0; branch advisor/074 sin merge) |
-| 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | TODO |
+| 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | DONE (2026-08-12) |
 | 076 | [RES incremental — descargar solo el año en curso](076-res-incremental-fetch.md) | P2 | M | MED | — | TODO |
 | 077 | [Caracterizar build_dev_db.py (cobertura 21% → ≥60%)](077-characterize-build-dev-db.md) | P2 | L | MED | — | TODO |
 | 078 | [Paralelizar CEAD y geometría (scrapes secuenciales)](078-parallelize-cead-geometria.md) | P2 | M | MED | — | TODO |

--- a/src/extractors/ine_ipc.py
+++ b/src/extractors/ine_ipc.py
@@ -41,15 +41,16 @@ SPANISH_MONTHS = {
 _MONTH_PATTERN = "|".join(SPANISH_MONTHS)
 
 # Acotación del par cifra/periodo (Plan 075): el span entre el h1 del IPC,
-# su cifra y su período no puede cruzar el cierre de un contenedor
-# (`</div>`), de modo que el valor de una tarjeta nunca se case con el
-# período de otra si el INE reordena el layout. Permite tags internos
-# (`<p>`, `<br>` — el fixture real tiene `</p><p>` entre cifra y período,
-# así que `[^<]` rompería el parseo) y admite hasta 500 chars de holgura:
-# la tarjeta real ocupa ~57. Si el INE separa cifra y período en bloques
-# distintos, este patrón deja de matchear y el override degrada — es la
-# primera alerta del rediseño, no un valor erróneo silencioso.
-_ACOTADO = r"(?:(?!</div>)[\s\S]){0,500}"
+# su cifra y su período no puede cruzar ni la apertura ni el cierre de un
+# contenedor (`<div` / `</div>`), de modo que el valor de una tarjeta nunca
+# se case con el período de otra si el INE reordena el layout — tampoco si
+# una tarjeta hermana entra ANIDADA tras el h1 (P2 de la review del PR #73).
+# Permite tags internos (`<p>`, `<br>` — el fixture real tiene `</p><p>`
+# entre cifra y período, así que `[^<]` rompería el parseo) y admite hasta
+# 500 chars de holgura: la tarjeta real ocupa ~57. Si el INE separa cifra y
+# período en bloques distintos, este patrón deja de matchear y el override
+# degrada — es la primera alerta del rediseño, no un valor erróneo silencioso.
+_ACOTADO = r"(?:(?!</div>|<div\b)[\s\S]){0,500}"
 
 # Anclado al <h1> del IPC; el par cifraV3/periodoCifraV3 siguiente es el del
 # propio IPC (mismo contenedor, span acotado), no el de una tarjeta hermana.

--- a/src/extractors/ine_ipc.py
+++ b/src/extractors/ine_ipc.py
@@ -40,13 +40,24 @@ SPANISH_MONTHS = {
 
 _MONTH_PATTERN = "|".join(SPANISH_MONTHS)
 
+# Acotación del par cifra/periodo (Plan 075): el span entre el h1 del IPC,
+# su cifra y su período no puede cruzar el cierre de un contenedor
+# (`</div>`), de modo que el valor de una tarjeta nunca se case con el
+# período de otra si el INE reordena el layout. Permite tags internos
+# (`<p>`, `<br>` — el fixture real tiene `</p><p>` entre cifra y período,
+# así que `[^<]` rompería el parseo) y admite hasta 500 chars de holgura:
+# la tarjeta real ocupa ~57. Si el INE separa cifra y período en bloques
+# distintos, este patrón deja de matchear y el override degrada — es la
+# primera alerta del rediseño, no un valor erróneo silencioso.
+_ACOTADO = r"(?:(?!</div>)[\s\S]){0,500}"
+
 # Anclado al <h1> del IPC; el par cifraV3/periodoCifraV3 siguiente es el del
-# propio IPC (lazy match), no el de una tarjeta hermana. Tolerante a tildes y
-# a clases adicionales (p. ej. `class="cifraV3 highlight"`).
+# propio IPC (mismo contenedor, span acotado), no el de una tarjeta hermana.
+# Tolerante a tildes y a clases adicionales (p. ej. `class="cifraV3 highlight"`).
 _PATTERN = re.compile(
     rf"<h1[^>]*>[^<]*[ÍI]ndice\s+de\s+Precios\s+al\s+Consumidor[^<]*</h1>"
-    rf"[\s\S]*?<p[^>]*class=\"[^\"]*\bcifraV3\b[^\"]*\"[^>]*>\s*(-?\d+(?:[,.]\d+)?)\s*%\s*</p>"
-    rf"[\s\S]*?<p[^>]*class=\"[^\"]*\bperiodoCifraV3\b[^\"]*\"[^>]*>\s*Variaci[oó]n\s+mensual\s+"
+    rf"{_ACOTADO}<p[^>]*class=\"[^\"]*\bcifraV3\b[^\"]*\"[^>]*>\s*(-?\d+(?:[,.]\d+)?)\s*%\s*</p>"
+    rf"{_ACOTADO}<p[^>]*class=\"[^\"]*\bperiodoCifraV3\b[^\"]*\"[^>]*>\s*Variaci[oó]n\s+mensual\s+"
     rf"({_MONTH_PATTERN})\s+(\d{{4}})",
     re.IGNORECASE,
 )

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -451,6 +451,67 @@ class IneIpcExtractorTests(unittest.TestCase):
         self.assertIsNotNone(reading)
         self.assertAlmostEqual(reading.value, 0.1, places=6)
 
+    def test_parse_rejects_mismatched_sibling_card(self):
+        """Plan 075: si una tarjeta hermana se intercala entre el h1 del IPC y
+        su cifra, el parser no puede casar el valor ajeno con el período del
+        IPC — el span acotado no cruza el cierre del contenedor de la tarjeta
+        hermana, así que devuelve None (degradación) antes que un valor
+        erróneo silencioso."""
+        from src.extractors.ine_ipc import parse_ine_ipc
+
+        html = """
+        <div class="cuadroIndV3">
+          <h1>Índice de Precios al Consumidor - IPC</h1>
+        </div>
+        <div class="cuadroIndV3">
+          <p class="cifraV3">-2,9%</p>
+          <p class="periodoCifraV3">Variación mensual julio 2026</p>
+        </div>
+        """
+        self.assertIsNone(parse_ine_ipc(html))
+
+    def test_parse_sibling_card_between_h1_and_value(self):
+        """Plan 075: una tarjeta hermana (ICT) completa intercalada entre el
+        h1 del IPC y su cifra NO puede contaminar el valor: el h1 y su cifra
+        deben compartir contenedor."""
+        from src.extractors.ine_ipc import parse_ine_ipc
+
+        html = """
+        <div class="cuadroIndV3">
+          <h1>Índice de Precios al Consumidor - IPC</h1>
+        </div>
+        <div class="cuadroIndV3">
+          <p class="cifraV3">-2,9%</p>
+          <p class="periodoCifraV3">Variación mensual junio 2026</p>
+        </div>
+        <div class="cuadroIndV3">
+          <p class="cifraV3">0,1%</p>
+          <p class="periodoCifraV3">Variación mensual julio 2026</p>
+        </div>
+        """
+        reading = parse_ine_ipc(html)
+        # La tarjeta hermana cierra su contenedor antes de la cifra del IPC:
+        # sin cruce de </div>, el parser no llega a la cifra posterior.
+        self.assertIsNone(reading)
+
+    def test_parse_same_card_value_and_period_ok(self):
+        """Plan 075 (contra-test): cuando cifra y período están en el MISMO
+        contenedor que el h1, el parseo funciona — el acotado no rompe el
+        layout actual."""
+        from src.extractors.ine_ipc import parse_ine_ipc
+
+        html = """
+        <div class="cuadroIndV3">
+          <h1>Índice de Precios al Consumidor - IPC</h1>
+          <p class="cifraV3">0,1%</p>
+          <p class="periodoCifraV3">Variación mensual julio 2026</p>
+        </div>
+        """
+        reading = parse_ine_ipc(html)
+        self.assertIsNotNone(reading)
+        self.assertEqual(reading.date_iso, "2026-07-01")
+        self.assertAlmostEqual(reading.value, 0.1, places=6)
+
     def test_parse_negative_variation(self):
         from src.extractors.ine_ipc import parse_ine_ipc
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -512,6 +512,24 @@ class IneIpcExtractorTests(unittest.TestCase):
         self.assertEqual(reading.date_iso, "2026-07-01")
         self.assertAlmostEqual(reading.value, 0.1, places=6)
 
+    def test_parse_rejects_nested_sibling_card_after_h1(self):
+        """Plan 075 (P2 de la review del PR #73): una tarjeta hermana
+        ANIDADA como <div> hijo tras el h1 del IPC no puede entregar su
+        valor como si fuera el IPC — el span acotado rechaza también la
+        apertura de un nuevo contenedor, no solo su cierre."""
+        from src.extractors.ine_ipc import parse_ine_ipc
+
+        html = """
+        <div class="cuadroIndV3">
+          <h1>Índice de Precios al Consumidor - IPC</h1>
+          <div class="cuadroIndV3">
+            <p class="cifraV3">-2,9%</p>
+            <p class="periodoCifraV3">Variación mensual julio 2026</p>
+          </div>
+        </div>
+        """
+        self.assertIsNone(parse_ine_ipc(html))
+
     def test_parse_negative_variation(self):
         from src.extractors.ine_ipc import parse_ine_ipc
 


### PR DESCRIPTION
## Plan 075 — Un valor ajeno ya no puede casarse con el período del IPC

**El bug:** el regex del override INE cruzaba cualquier distancia entre `cifraV3` y `periodoCifraV3` (`[\s\S]*?`). Si el INE reordenaba el layout e intercalaba otra tarjeta, un valor erróneo entraba silenciosamente al bundle — el único freno (anomalías, Plan 074) quedaba debilitado.

### Cambios

1. **`ine_ipc.py` — span acotado por contenedor**: el par h1 → cifra → período no puede cruzar el cierre de un `<div>`: `(?:(?!</div>)[\s\S]){0,500}`.
2. **Desvío documentado del plan**: la propuesta `[^<]{0,200}` rompía el fixture real — el span cifra→período contiene `<p>`/`</p>` (mide ~57 chars con tags, no 200 de texto plano). Usé la variante robusta que el propio plan listaba ("parsear dentro del mismo bloque contenedor").
3. **3 tests adversariales**: tarjeta hermana intercalada entre h1 y cifra → `None` (nunca valor ajeno); cifra de otra tarjeta antes del período del IPC → `None`; contra-test: mismo contenedor → parsea (0,1% jul-2026).

### Verificación

Fixture real sigue parseando 0,1% jul-2026 · 894 tests + 1 skip · doctor/lint verdes