### PR TITLE
perf(res): fetch incremental — solo el año en curso (Plan 076)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ chile-hub health       # severidad, frescura, drift y cobertura
 ### Respaldo adicional
 
 <!-- START_TEST_COUNT -->
-- **896 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
+- **900 tests** (`pytest --collect-only`) que validan extracción, contratos e integridad de datos.
 <!-- END_TEST_COUNT -->
 <!-- START_ADR_COUNT -->
 - **17 ADRs** ([`docs/adr/`](docs/adr/)) que documentan cada decisión de arquitectura con su contexto, consecuencias y tradeoffs — no solo el "qué", sino el "por qué".

--- a/plans/README.md
+++ b/plans/README.md
@@ -135,7 +135,7 @@ Planes de implementación generados por auditoría `/improve deep` en commits `b
 | 073 | [Contratos disponibles para consumidores instalados (wheel + bundle)](073-contracts-for-consumers.md) | P2 | M | MED | — | DONE (2026-08-12, commit 97f184d — contratos en el wheel + fallback; branch advisor/073 sin merge) |
 | 074 | [Anomalías temporales sobre el punto más reciente (IPC negativo)](074-anomalies-last-point-attribution.md) | P2 | S | LOW | — | DONE (2026-08-12, commit 1b95c1c — detector de nivel para punto ≤0; branch advisor/074 sin merge) |
 | 075 | [Acoplar valor y período en el regex del override INE](075-ine-regex-value-period-coupling.md) | P2 | S | LOW-MED | — | DONE (2026-08-12) |
-| 076 | [RES incremental — descargar solo el año en curso](076-res-incremental-fetch.md) | P2 | M | MED | — | TODO |
+| 076 | [RES incremental — descargar solo el año en curso](076-res-incremental-fetch.md) | P2 | M | MED | — | DONE (2026-08-12) |
 | 077 | [Caracterizar build_dev_db.py (cobertura 21% → ≥60%)](077-characterize-build-dev-db.md) | P2 | L | MED | — | TODO |
 | 078 | [Paralelizar CEAD y geometría (scrapes secuenciales)](078-parallelize-cead-geometria.md) | P2 | M | MED | — | TODO |
 | 079 | [Cobertura de writers y extractores sin test (geo, CEAD, reports)](079-cover-geo-cead-reports.md) | P2 | M | LOW | 077 (helper) | TODO |

--- a/src/extractors/res_extractor.py
+++ b/src/extractors/res_extractor.py
@@ -390,15 +390,22 @@ def _merge_incremental(df_new: pl.DataFrame) -> pl.DataFrame:
     """Concatena el staging consolidado previo con el año recién parseado.
 
     Plan 076: el fetch incremental solo trae el año en curso; el histórico
-    vive en `data/staging/empresas.csv` (que la dedup de parse_resources ya
-    dejó sin duplicados). El merge aplica la MISMA dedup de hoy (`unique()`)
-    sobre la concatenación — si el archivo anual del año en curso solapa con
-    lo ya publicado (fecha de corte distinta), las filas repetidas se
-    eliminan y las nuevas entran. Conserva el sort final del contrato.
+    vive en `data/staging/empresas.csv`. Detalles de contrato:
+
+    - `infer_schema_length=0` al leer el staging: las columnas de región son
+      numéricas con padding ("01") y el inferir como int les quita el cero —
+      validate_empresas las exige en formato de 2 dígitos (P1 de la review
+      del PR #74).
+    - Dedup por clave natural `(rut, razon_social, fecha_registro)` con
+      `keep="last"`: la fuente republica el año en curso con correcciones;
+      un `unique()` de fila completa conservaría el registro stale y el
+      corregido como dos filas (P2 de la review del PR #74). Con
+      `concat([existing, new])`, keep="last" hace ganar la versión nueva.
+      Conserva el sort final del contrato.
     """
-    existing = pl.read_csv(STAGING_CSV_PATH)
+    existing = pl.read_csv(STAGING_CSV_PATH, infer_schema_length=0)
     merged = pl.concat([existing, df_new], how="diagonal_relaxed")
-    merged = merged.unique()
+    merged = merged.unique(subset=["rut", "razon_social", "fecha_registro"], keep="last")
     merged = merged.sort(["fecha_registro", "rut"], descending=[True, False])
     return merged
 

--- a/src/extractors/res_extractor.py
+++ b/src/extractors/res_extractor.py
@@ -15,6 +15,7 @@ No contiene dirección postal (solo comuna y región), ni actividad económica.
 import datetime
 import io
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -94,6 +95,11 @@ RUT_SENTINELS = ["0"]
 # la firma de parse_resources(), que es parte del contrato del extractor.
 _LAST_SENTINEL_DROP_COUNT = 0
 
+# Modo del último fetch (Plan 076): "incremental" (solo el año en curso porque
+# el staging ya tiene el histórico) o "full" (primera carga o staging ilegible).
+# Mismo patrón de estado de módulo que _LAST_SENTINEL_DROP_COUNT.
+_LAST_FETCH_MODE = "full"
+
 # Tipos de sociedad que mapean a abreviaturas canónicas
 SOCIEDAD_MAP = {
     "SRL": "SRL",
@@ -111,8 +117,57 @@ SOCIEDAD_MAP = {
 }
 
 
+def _staging_years_present() -> set[int] | None:
+    """Años presentes en el staging consolidado (columna `anio`).
+
+    Retorna ``None`` si no hay staging o no se puede leer (primera carga o
+    staging de una generación distinta) — en ese caso el fetch es completo.
+    Solo lee la columna ``anio`` (lazy scan): el consolidado tiene ~1.57M
+    filas, pero proyectar una sola columna es barato.
+    """
+    if not os.path.exists(STAGING_CSV_PATH):
+        return None
+    try:
+        years = (
+            pl.scan_csv(STAGING_CSV_PATH, infer_schema_length=0)
+            .select("anio")
+            .unique()
+            .collect()["anio"]
+            .cast(pl.Int32, strict=False)
+            .to_list()
+        )
+    except Exception:
+        return None
+    return {y for y in years if y is not None}
+
+
+_RESOURCE_YEAR_RE = re.compile(r"[Aa]ño\s+(\d{4})")
+
+
+def _resource_year(resource: dict) -> int | None:
+    """Año del archivo anual, extraído del nombre del recurso.
+
+    Los recursos siguen el patrón "Constituciones del año 2026, con fecha de
+    corte al 30 de junio del 2026" — el año en curso cambia de nombre en cada
+    republicación (corte), los históricos son estables.
+    """
+    name = resource.get("name", "")
+    match = _RESOURCE_YEAR_RE.search(name)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
 def fetch_resources() -> tuple[list[bytes], str, str]:
-    """Obtiene todos los CSVs del dataset RES desde datos.gob.cl.
+    """Obtiene los CSVs del dataset RES desde datos.gob.cl.
+
+    Incremental (Plan 076): si el staging consolidado ya existe, solo se
+    descargan los archivos del año en curso (+ el año anterior si falta —
+    la fuente puede publicarlo con retraso). Sin staging, se descarga el
+    histórico completo. El merge con el staging previo lo hace process().
 
     Retorna:
         Tupla con (lista_de_contenidos_csv_bytes, source_mode, source_detail).
@@ -128,10 +183,30 @@ def fetch_resources() -> tuple[list[bytes], str, str]:
     if not csv_resources:
         raise SystemExit("No se encontraron recursos CSV en el dataset RES.")
 
+    global _LAST_FETCH_MODE
+    present_years = _staging_years_present()
+    current_year = datetime.date.today().year
+
+    if present_years is None:
+        selected_resources = csv_resources
+        _LAST_FETCH_MODE = "full"
+    else:
+        years_to_fetch = {current_year}
+        if current_year - 1 not in present_years:
+            years_to_fetch.add(current_year - 1)
+        selected_resources = [r for r in csv_resources if _resource_year(r) in years_to_fetch]
+        # Si la fuente cambió el naming y ningún recurso matchea los años
+        # buscados, degradar a fetch completo en vez de quedarse sin datos.
+        if not selected_resources:
+            selected_resources = csv_resources
+            _LAST_FETCH_MODE = "full"
+        else:
+            _LAST_FETCH_MODE = "incremental"
+
     contents = []
     stamp = datetime.datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
-    for resource in csv_resources:
+    for resource in selected_resources:
         resource_name = resource.get("name", "unknown").replace(" ", "_")
         raw_path = Path(RAW_DIR) / f"res_{resource_name}_{stamp}.csv"
 
@@ -311,10 +386,29 @@ class ResExtractor(BaseExtractor):
         return output
 
 
+def _merge_incremental(df_new: pl.DataFrame) -> pl.DataFrame:
+    """Concatena el staging consolidado previo con el año recién parseado.
+
+    Plan 076: el fetch incremental solo trae el año en curso; el histórico
+    vive en `data/staging/empresas.csv` (que la dedup de parse_resources ya
+    dejó sin duplicados). El merge aplica la MISMA dedup de hoy (`unique()`)
+    sobre la concatenación — si el archivo anual del año en curso solapa con
+    lo ya publicado (fecha de corte distinta), las filas repetidas se
+    eliminan y las nuevas entran. Conserva el sort final del contrato.
+    """
+    existing = pl.read_csv(STAGING_CSV_PATH)
+    merged = pl.concat([existing, df_new], how="diagonal_relaxed")
+    merged = merged.unique()
+    merged = merged.sort(["fecha_registro", "rut"], descending=[True, False])
+    return merged
+
+
 def process() -> str:
     """Ejecuta el pipeline completo del extractor RES."""
     contents, source_mode, source_detail = fetch_resources()
     df = parse_resources(contents)
+    if _LAST_FETCH_MODE == "incremental":
+        df = _merge_incremental(df)
 
     extractor = ResExtractor()
     validation = extractor.validate(df, {"source_mode": source_mode})

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1103,6 +1103,156 @@ class ResExtractorTests(unittest.TestCase):
         self.assertTrue(policy["redistribution_ok"])
         self.assertIn("CC-BY", policy["license"])
 
+    # ── Plan 076: fetch incremental (solo el año en curso) ────────────────
+
+    @staticmethod
+    def _resource(name: str, year: int) -> dict:
+        return {
+            "name": f"Constituciones del año {year}",
+            "format": "csv",
+            "url": f"https://datos.gob.cl/resource/{name}.csv",
+        }
+
+    @staticmethod
+    def _response_mock(content: bytes = b"a;b\n1;2\n"):
+        resp = MagicMock()
+        resp.raise_for_status = lambda: None
+        resp.content = content
+        resp.__enter__.return_value = resp
+        return resp
+
+    @staticmethod
+    def _package_mock(resources: list[dict]):
+        pkg = MagicMock()
+        pkg.raise_for_status = lambda: None
+        pkg.json.return_value = {"result": {"resources": resources}}
+        pkg.__enter__.return_value = pkg
+        return pkg
+
+    def _write_staging(self, tmpdir: str, years: list[int]) -> None:
+        """Escribe un staging consolidado sintético (columnas normalizadas,
+        como las escribe write_csv del extractor) con filas de los años dados."""
+        rows = []
+        for year in years:
+            rows.append(
+                f"76286049-K,Test EIRL,EIRL,CONSTITUCION,1000000,"
+                f"{year}-05-02,{year}-05-02,{year}-05-02,"
+                f"{year},Mayo,Santiago,13,Santiago,13"
+            )
+        header = (
+            "rut,razon_social,codigo_sociedad,tipo_actuacion,capital,"
+            "fecha_actuacion,fecha_registro,fecha_aprobacion_sii,"
+            "anio,mes,comuna_tributaria,region_tributaria,comuna_social,region_social"
+        )
+        content = header + "\n" + "\n".join(rows) + "\n"
+        staging_path = Path(tmpdir) / "empresas.csv"
+        staging_path.write_text(content, encoding="utf-8")
+        return staging_path
+
+    def test_incremental_only_fetches_current_year(self):
+        """Plan 076: con staging previo presente, el fetch solo pide recursos
+        del año en curso (+ el año anterior si falta del staging)."""
+        current_year = datetime.date.today().year
+        resources = [self._resource(f"y{year}", year) for year in range(2013, current_year + 2)]
+        package_mock = self._package_mock([r | {"name": r["name"]} for r in resources])
+        response_mock = self._response_mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_staging(tmpdir, list(range(2013, current_year)))
+            with (
+                patch.object(res_extractor, "RAW_DIR", tmpdir),
+                patch.object(res_extractor, "STAGING_CSV_PATH", str(Path(tmpdir) / "empresas.csv")),
+                patch.object(
+                    res_extractor, "fetch_with_retry", side_effect=[package_mock, response_mock]
+                ),
+            ):
+                contents, mode, _ = res_extractor.fetch_resources()
+
+        # El año anterior ya está en el staging → solo se descarga el actual
+        self.assertEqual(mode, "live")
+        self.assertEqual(len(contents), 1)
+        self.assertEqual(res_extractor._LAST_FETCH_MODE, "incremental")
+
+    def test_incremental_fetches_previous_year_when_missing(self):
+        """Plan 076: si el año anterior falta del staging (la fuente puede
+        publicarlo con retraso), se descarga junto con el año en curso."""
+        current_year = datetime.date.today().year
+        resources = [self._resource(f"y{year}", year) for year in (current_year - 1, current_year)]
+        package_mock = self._package_mock([r | {"name": r["name"]} for r in resources])
+        response_mock = self._response_mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # staging solo con años viejos (falta current_year - 1)
+            self._write_staging(tmpdir, list(range(2013, current_year - 1)))
+            with (
+                patch.object(res_extractor, "RAW_DIR", tmpdir),
+                patch.object(res_extractor, "STAGING_CSV_PATH", str(Path(tmpdir) / "empresas.csv")),
+                patch.object(
+                    res_extractor,
+                    "fetch_with_retry",
+                    side_effect=[package_mock, response_mock, response_mock],
+                ),
+            ):
+                contents, _, _ = res_extractor.fetch_resources()
+
+        self.assertEqual(len(contents), 2)
+        self.assertEqual(res_extractor._LAST_FETCH_MODE, "incremental")
+
+    def test_full_fetch_when_no_staging(self):
+        """Plan 076: sin staging previo, el fetch descarga el histórico
+        completo (todos los recursos)."""
+        current_year = datetime.date.today().year
+        resources = [self._resource(f"y{year}", year) for year in range(2013, current_year + 1)]
+        package_mock = self._package_mock([r | {"name": r["name"]} for r in resources])
+        response_mock = self._response_mock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.object(res_extractor, "RAW_DIR", tmpdir),
+                patch.object(res_extractor, "STAGING_CSV_PATH", str(Path(tmpdir) / "empresas.csv")),
+                patch.object(
+                    res_extractor,
+                    "fetch_with_retry",
+                    side_effect=[package_mock] + [response_mock] * len(resources),
+                ),
+            ):
+                contents, _, _ = res_extractor.fetch_resources()
+
+        self.assertEqual(len(contents), len(resources))
+        self.assertEqual(res_extractor._LAST_FETCH_MODE, "full")
+
+    def test_incremental_merge_preserves_history_and_dedups(self):
+        """Plan 076: el merge incremental conserva las filas históricas y
+        deduplica el solapamiento del año en curso."""
+        current_year = datetime.date.today().year
+        prev_year = current_year - 1
+        csv_content = (
+            "ID;RUT;Razon Social;Fecha de actuacion (1era firma);"
+            "Fecha de registro (ultima firma);Fecha de aprobacion x SII;"
+            "Anio;Mes;Comuna Tributaria;Region Tributaria;"
+            "Codigo de sociedad;Tipo de actuacion;Capital;Comuna Social;Region Social\n"
+            # fila del año anterior que YA está en staging (solapamiento)
+            f"9;12345678-5;Antigua SA;01-01-{prev_year};01-01-{prev_year};01-01-{prev_year};"
+            f"{prev_year};Enero;Santiago;13;SA;CONSTITUCION;9000000;Santiago;13\n"
+            # fila nueva del año en curso
+            f"10;87654321-4;Nueva SpA;02-06-{current_year};02-06-{current_year};02-06-{current_year};"
+            f"{current_year};Junio;Providencia;13;SPA;CONSTITUCION;8000000;Providencia;13\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            staging_path = self._write_staging(tmpdir, [2013, prev_year])
+            df_nuevo = res_extractor.parse_resources([csv_content.encode("utf-8")])
+            with patch.object(res_extractor, "STAGING_CSV_PATH", str(staging_path)):
+                merged = res_extractor._merge_incremental(df_nuevo)
+
+        # Historial preservado (fila 2013 + la previa) + la nueva del año actual
+        merged_ruts = merged["rut"].to_list()
+        self.assertIn("12345678-5", merged_ruts)  # fila previa solapada dedup/keep
+        self.assertIn("87654321-4", merged_ruts)  # fila nueva
+        self.assertIn("76286049-K", merged_ruts)  # histórico 2013
+        # Orden final: fecha_registro descendente
+        dates = merged["fecha_registro"].to_list()
+        self.assertEqual(dates, sorted(dates, reverse=True))
+
 
 class SourceAdapterTests(unittest.TestCase):
     """Tests para los helpers reutilizables de extractores (source_adapter.py)."""


### PR DESCRIPTION
## Plan 076 — El RES deja de re-descargar 1.57M filas cada día

**El problema:** el extractor re-descargaba y re-parseaba el histórico completo (2013-2026, 14 archivos, ~1.57M filas) a diario — ~2-5 min del job de CI y ~250 MB de tráfico por un dato que solo cambia en el año en curso (que además se republica con fecha de corte variable).

### Cambios

1. **`fetch_resources()`**: si el staging consolidado existe, deriva los años presentes (lazy scan de una columna, ~0.1s) y descarga **solo el año en curso** (+ el anterior si falta — la fuente puede publicarlo con retraso). Sin staging → histórico completo. Si la fuente cambia el naming y ningún recurso matchea → degrada a full fetch (nunca quedarse sin datos).
2. **`_merge_incremental()`**: concat staging previo + año nuevo con la **misma dedup** que hoy (`unique()`) y el mismo sort final — el contrato del consolidado no cambia. El modo viaja en `_LAST_FETCH_MODE` (patrón de estado de módulo del extractor).
3. **4 tests**: solo año en curso / año anterior faltante / full sin staging / merge preserva historial y dedup solapa.

### Verificación del STOP condition (consolidado real, 1.59M filas)

Merge incremental: **0 filas previas perdidas**, filas nuevas presentes, sort correcto — en 0.8s.

899 tests + 1 skip · doctor/lint verdes