### PR TITLE
fix(test): contrato de delivery incluye ine_override (destraba publish)

### DIFF
--- a/tests/test_chile_hub.py
+++ b/tests/test_chile_hub.py
@@ -45,6 +45,9 @@ INDICADORES_NON_SYNTHETIC_DELIVERY = {
     "published_backfill",
     "raw_recovery",
     "preserved_existing",
+    # Override de último recurso desde el INE (Plan 069, ADR-017): delivery
+    # visible para que el gate de publicación evalúe el dato real scrapeado.
+    "ine_override",
 }
 EXPECTED_DATASET_COUNT = 19
 # Datasets candidate (p. ej. consumo_electrico_comunal) no tienen tarjeta en


### PR DESCRIPTION
## Fix operativo — el publish diario fallaba por contrato desactualizado

El dispatch de hoy (publish=true) construyó los datos con la cadena completa sana — **mindicador 0 puntos para ipc, override INE 0.1% jul-2026, delivery `ine_override`, publication policy pasa sin override** — pero `test_indicadores_partial_refresh_contract_is_published` falló: `INDICADORES_NON_SYNTHETIC_DELIVERY` no incluía `ine_override` (el delivery nuevo del Plan 069/ADR-017 quedó visible en producción pero invisible para el contrato).

El fix: 1 línea en el set de deliveries válidos. 170 tests de `test_chile_hub.py` pasan localmente.